### PR TITLE
check slice size before make

### DIFF
--- a/transaction/input.go
+++ b/transaction/input.go
@@ -23,8 +23,13 @@ sequence_no	               normally 0xFFFFFFFF; irrelevant unless transaction's 
                            lock_time is > 0
 */
 
-// DefaultSequenceNumber is the default starting sequence number
-const DefaultSequenceNumber uint32 = 0xFFFFFFFF
+const (
+	// DefaultSequenceNumber is the default starting sequence number
+	DefaultSequenceNumber uint32 = 0xFFFFFFFF
+
+	MB           = 1024 * 1024 // 1 MB in bytes
+	MaxSliceSize = 100 * MB    // 100 MB in bytes
+)
 
 // TransactionInput is a representation of a transaction input
 //
@@ -98,6 +103,9 @@ func (i *TransactionInput) readFrom(r io.Reader, extended bool) (int64, error) {
 		return bytesRead, err
 	}
 
+	if l >= MaxSliceSize {
+		return bytesRead, fmt.Errorf("scriptBytes size %d exceeds acceptable %d", l, MaxSliceSize)
+	}
 	scriptBytes := make([]byte, l)
 	n, err = io.ReadFull(r, scriptBytes)
 	bytesRead += int64(n)
@@ -135,6 +143,9 @@ func (i *TransactionInput) readFrom(r io.Reader, extended bool) (int64, error) {
 			return bytesRead, err
 		}
 
+		if scriptLen >= MaxSliceSize {
+			return bytesRead, fmt.Errorf("scriptBytes size %d exceeds acceptable %d", scriptLen, MaxSliceSize)
+		}
 		scriptBytes := make([]byte, scriptLen)
 		n, err := io.ReadFull(r, scriptBytes)
 		bytesRead += int64(n)

--- a/transaction/output.go
+++ b/transaction/output.go
@@ -48,6 +48,9 @@ func (o *TransactionOutput) ReadFrom(r io.Reader) (int64, error) {
 		return bytesRead, err
 	}
 
+	if l >= MaxSliceSize {
+		return bytesRead, fmt.Errorf("scriptBytes size %d exceeds acceptable %d", l, MaxSliceSize)
+	}
 	scriptBytes := make([]byte, l)
 	n, err = io.ReadFull(r, scriptBytes)
 	bytesRead += int64(n)


### PR DESCRIPTION
## Description of Changes

We just blindly trust data from user. We are parsing some int and making slice of that size. What if that value is too big - causing panic.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment
- [ ] All tests pass when using `go test ./...`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I ran `golangci-lint run`
- [ ] I have run `go fmt` and `go vet` one final time before requesting a review