### PR TITLE
fix: tx.FromBEEF - nil pointer dereference

### DIFF
--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -31,7 +31,7 @@ func (t *Transaction) FromBEEF(beef []byte) error {
 		return fmt.Errorf("failed to parse BEEF bytes: %w", err)
 	}
 	*t = *tx
-	return err
+	return nil
 }
 
 func NewBeefV1() *Beef {

--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -27,6 +27,9 @@ const ATOMIC_BEEF = uint32(0x01010101) // BRC-95
 
 func (t *Transaction) FromBEEF(beef []byte) error {
 	tx, err := NewTransactionFromBEEF(beef)
+	if err != nil {
+		return fmt.Errorf("failed to parse BEEF bytes: %w", err)
+	}
 	*t = *tx
 	return err
 }

--- a/transaction/beef_test.go
+++ b/transaction/beef_test.go
@@ -57,7 +57,12 @@ func TestFromBEEF(t *testing.T) {
 
 	_, err = NewBeefFromTransaction(tx)
 	require.NoError(t, err, "NewBeefFromTransaction method failed")
+}
 
+func TestFromBeefErrorCase(t *testing.T) {
+	tx := &Transaction{}
+	err := tx.FromBEEF([]byte("invalid data"))
+	require.Error(t, err, "FromBEEF method should fail with invalid data")
 }
 
 func TestNewEmptyBEEF(t *testing.T) {


### PR DESCRIPTION
## Description of Changes

When:
`tx.FromBEEF(wrongData)`

Was:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```

Now:
It returns error. 