### PR TITLE
Add context parameter to ChainTracker interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Table of Contents
 
+- [1.2.4 - 2025-01-30](#124---2025-01-30)
 - [1.2.1 - 2025-06-12](#121---2025-06-12)
 - [1.2.0 - 2025-06-10](#120---2025-06-10)
 - [1.1.27 - 2025-05-15](#1127---2025-05-15)
@@ -35,6 +36,11 @@ All notable changes to this project will be documented in this file. The format 
 - [1.1.1 - 2024-08-28](#111---2024-08-28)
 - [1.1.0 - 2024-08-19](#110---2024-08-19)
 - [1.0.0 - 2024-06-06](#100---2024-06-06)
+
+## [1.2.4] - 2025-01-30
+
+### Changed
+- Add context parameter to ChainTracker.IsValidRootForHeight for cancellation/timeout support
 
 ## [1.2.1] - 2025-06-12
 

--- a/docs/examples/validate_spv/validate_spv.go
+++ b/docs/examples/validate_spv/validate_spv.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 
@@ -32,7 +33,7 @@ func main() {
 		return
 	}
 
-	valid, err := client.IsValidRootForHeight(root, tx.MerklePath.BlockHeight)
+	valid, err := client.IsValidRootForHeight(context.Background(), root, tx.MerklePath.BlockHeight)
 	if err != nil {
 		fmt.Println("Error validating root for height:", err)
 		return

--- a/docs/examples/verify_beef/verify_beef.go
+++ b/docs/examples/verify_beef/verify_beef.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/bsv-blockchain/go-sdk/spv"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 )
@@ -15,6 +17,6 @@ func main() {
 		panic(err)
 	}
 	// This ensures the BEEF structure is legitimate
-	verified, _ := tx.MerklePath.Verify(tx.TxID(), &spv.GullibleHeadersClient{})
+	verified, _ := tx.MerklePath.Verify(context.Background(), tx.TxID(), &spv.GullibleHeadersClient{})
 	println(verified)
 }

--- a/docs/examples/verify_transaction/verify_transaction.go
+++ b/docs/examples/verify_transaction/verify_transaction.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/bsv-blockchain/go-sdk/spv"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 )
@@ -16,6 +18,6 @@ func main() {
 	}
 	// This ensures the BEEF structure is legitimate, the scripts are valid, and the merkle path is correct
 	// Also optionally verifies fees
-	verified, _ := spv.Verify(tx, &spv.GullibleHeadersClient{}, nil)
+	verified, _ := spv.Verify(context.Background(), tx, &spv.GullibleHeadersClient{}, nil)
 	println(verified)
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=bsv_go-sdk
+sonar.projectKey=bsv-blockchain_go-sdk
 sonar.organization=bsv-blockchain
 sonar.projectName=Go SDK
 sonar.projectDescription=BSV BLOCKCHAIN | Software Development Kit for Go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=bitcoin-sv_go-sdk
-sonar.organization=bitcoin-sv
+sonar.projectKey=bsv_go-sdk
+sonar.organization=bsv-blockchain
 sonar.projectName=Go SDK
 sonar.projectDescription=BSV BLOCKCHAIN | Software Development Kit for Go
 sonar.projectVersion=1.0.0

--- a/spv/scripts_only.go
+++ b/spv/scripts_only.go
@@ -1,10 +1,14 @@
 package spv
 
-import "github.com/bsv-blockchain/go-sdk/chainhash"
+import (
+	"context"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+)
 
 type GullibleHeadersClient struct{}
 
-func (g *GullibleHeadersClient) IsValidRootForHeight(merkleRoot *chainhash.Hash, height uint32) (bool, error) {
+func (g *GullibleHeadersClient) IsValidRootForHeight(ctx context.Context, merkleRoot *chainhash.Hash, height uint32) (bool, error) {
 	// DO NOT USE IN A REAL PROJECT due to security risks of accepting any merkle root as valid without verification
 	return true, nil
 }

--- a/spv/verify.go
+++ b/spv/verify.go
@@ -1,6 +1,7 @@
 package spv
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bsv-blockchain/go-sdk/script/interpreter"
@@ -8,7 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-sdk/transaction/chaintracker"
 )
 
-func Verify(t *transaction.Transaction,
+func Verify(ctx context.Context, t *transaction.Transaction,
 	chainTracker chaintracker.ChainTracker,
 	feeModel transaction.FeeModel) (bool, error) {
 	verifiedTxids := make(map[string]struct{})
@@ -28,7 +29,7 @@ func Verify(t *transaction.Transaction,
 		}
 
 		if tx.MerklePath != nil {
-			if isValid, err := tx.MerklePath.Verify(txid, chainTracker); err != nil {
+			if isValid, err := tx.MerklePath.Verify(ctx, txid, chainTracker); err != nil {
 				return false, err
 			} else if isValid {
 				verifiedTxids[txidStr] = struct{}{}
@@ -80,6 +81,6 @@ func Verify(t *transaction.Transaction,
 	return true, nil
 }
 
-func VerifyScripts(t *transaction.Transaction) (bool, error) {
-	return Verify(t, &GullibleHeadersClient{}, nil)
+func VerifyScripts(ctx context.Context, t *transaction.Transaction) (bool, error) {
+	return Verify(ctx, t, &GullibleHeadersClient{}, nil)
 }

--- a/spv/verify_test.go
+++ b/spv/verify_test.go
@@ -3,6 +3,7 @@
 package spv
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
 
@@ -17,7 +18,7 @@ const BEEF = "AQC+7wH+kQYNAAcCVAIKXThHm90iVbs15AIfFQEYl5xesbHCXMkYy9SqoR1vNVUAAZ
 func TestSPVVerify(t *testing.T) {
 	tx, err := transaction.NewTransactionFromBEEFHex(BRC62Hex)
 	require.NoError(t, err)
-	verified, err := Verify(tx, &GullibleHeadersClient{}, nil)
+	verified, err := Verify(context.Background(), tx, &GullibleHeadersClient{}, nil)
 	require.NoError(t, err)
 	require.True(t, verified)
 }
@@ -27,7 +28,7 @@ func TestSPVVerifyScripts(t *testing.T) {
 	require.NoError(t, err)
 	tx, err := transaction.NewTransactionFromBEEF(buf)
 	require.NoError(t, err)
-	verified, err := VerifyScripts(tx)
+	verified, err := VerifyScripts(context.Background(), tx)
 	require.NoError(t, err)
 	require.True(t, verified)
 }
@@ -40,7 +41,7 @@ func TestSPVVerifyWithSufficientFee(t *testing.T) {
 		Satoshis: 10,
 	}
 
-	verified, err := Verify(tx, &GullibleHeadersClient{}, feeModel)
+	verified, err := Verify(context.Background(), tx, &GullibleHeadersClient{}, feeModel)
 	require.NoError(t, err)
 	require.True(t, verified)
 }
@@ -53,7 +54,7 @@ func TestSPVVerifyWithInsufficientFee(t *testing.T) {
 		Satoshis: 1,
 	}
 
-	verified, err := Verify(tx, &GullibleHeadersClient{}, feeModel)
+	verified, err := Verify(context.Background(), tx, &GullibleHeadersClient{}, feeModel)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fee is too low")
 	require.False(t, verified)

--- a/transaction/beef.go
+++ b/transaction/beef.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -780,7 +781,7 @@ func (b *Beef) IsValid(allowTxidOnly bool) bool {
 	return r.valid
 }
 
-func (b *Beef) Verify(chainTracker chaintracker.ChainTracker, allowTxidOnly bool) (bool, error) {
+func (b *Beef) Verify(ctx context.Context, chainTracker chaintracker.ChainTracker, allowTxidOnly bool) (bool, error) {
 	r := b.verifyValid(allowTxidOnly)
 	if !r.valid {
 		return false, nil
@@ -790,7 +791,7 @@ func (b *Beef) Verify(chainTracker chaintracker.ChainTracker, allowTxidOnly bool
 		if err != nil {
 			return false, err
 		}
-		ok, err := chainTracker.IsValidRootForHeight(h, height)
+		ok, err := chainTracker.IsValidRootForHeight(ctx, h, height)
 		if err != nil || !ok {
 			return false, err
 		}

--- a/transaction/chaintracker/chaintracker.go
+++ b/transaction/chaintracker/chaintracker.go
@@ -1,7 +1,11 @@
 package chaintracker
 
-import "github.com/bsv-blockchain/go-sdk/chainhash"
+import (
+	"context"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+)
 
 type ChainTracker interface {
-	IsValidRootForHeight(root *chainhash.Hash, height uint32) (bool, error)
+	IsValidRootForHeight(ctx context.Context, root *chainhash.Hash, height uint32) (bool, error)
 }

--- a/transaction/chaintracker/headers_client/headers_client.go
+++ b/transaction/chaintracker/headers_client/headers_client.go
@@ -34,7 +34,7 @@ type Client struct {
 	ApiKey string
 }
 
-func (c Client) IsValidRootForHeight(root *chainhash.Hash, height uint32) (bool, error) {
+func (c Client) IsValidRootForHeight(ctx context.Context, root *chainhash.Hash, height uint32) (bool, error) {
 	type requestBody struct {
 		MerkleRoot  string `json:"merkleRoot"`
 		BlockHeight uint32 `json:"blockHeight"`
@@ -46,7 +46,7 @@ func (c Client) IsValidRootForHeight(root *chainhash.Hash, height uint32) (bool,
 		return false, fmt.Errorf("error marshaling JSON: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", c.Url+"/api/v1/chain/merkleroot/verify", bytes.NewBuffer(jsonPayload))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.Url+"/api/v1/chain/merkleroot/verify", bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return false, fmt.Errorf("error creating request: %v", err)
 	}

--- a/transaction/chaintracker/whatsonchain.go
+++ b/transaction/chaintracker/whatsonchain.go
@@ -43,17 +43,17 @@ func NewWhatsOnChain(network Network, apiKey string) *WhatsOnChain {
 	}
 }
 
-// Assuming BlockHeader is defined elsewhere
-func (w *WhatsOnChain) GetBlockHeader(height uint32) (header *BlockHeader, err error) {
+// GetBlockHeader retrieves the block header for a given height
+func (w *WhatsOnChain) GetBlockHeader(ctx context.Context, height uint32) (header *BlockHeader, err error) {
 	url := fmt.Sprintf("%s/block/%d/header", w.baseURL, height)
-	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Authorization", w.ApiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := w.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +74,8 @@ func (w *WhatsOnChain) GetBlockHeader(height uint32) (header *BlockHeader, err e
 	return header, nil
 }
 
-func (w *WhatsOnChain) IsValidRootForHeight(root *chainhash.Hash, height uint32) (bool, error) {
-	if header, err := w.GetBlockHeader(height); err != nil {
+func (w *WhatsOnChain) IsValidRootForHeight(ctx context.Context, root *chainhash.Hash, height uint32) (bool, error) {
+	if header, err := w.GetBlockHeader(ctx, height); err != nil {
 		return false, err
 	} else {
 		return header.MerkleRoot.IsEqual(root), nil

--- a/transaction/chaintracker/whatsonchain_test.go
+++ b/transaction/chaintracker/whatsonchain_test.go
@@ -3,6 +3,7 @@
 package chaintracker
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +54,7 @@ func TestWhatsOnChainGetBlockHeaderSuccess(t *testing.T) {
 		client:  ts.Client(),
 	}
 
-	header, err := woc.GetBlockHeader(100)
+	header, err := woc.GetBlockHeader(context.Background(), 100)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 		return // Add this return statement
@@ -81,7 +82,7 @@ func TestWhatsOnChainGetBlockHeaderNotFound(t *testing.T) {
 		client:  ts.Client(),
 	}
 
-	header, err := woc.GetBlockHeader(100)
+	header, err := woc.GetBlockHeader(context.Background(), 100)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -105,7 +106,7 @@ func TestWhatsOnChainGetBlockHeaderErrorResponse(t *testing.T) {
 		client:  ts.Client(),
 	}
 
-	header, err := woc.GetBlockHeader(100)
+	header, err := woc.GetBlockHeader(context.Background(), 100)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -136,7 +137,7 @@ func TestWhatsOnChainIsValidRootForHeightSuccess(t *testing.T) {
 		client:  ts.Client(),
 	}
 
-	isValid, err := woc.IsValidRootForHeight(&merkleRootHash, 100)
+	isValid, err := woc.IsValidRootForHeight(context.Background(), &merkleRootHash, 100)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -168,7 +169,7 @@ func TestWhatsOnChainIsValidRootForHeightInvalidRoot(t *testing.T) {
 		client:  ts.Client(),
 	}
 
-	isValid, err := woc.IsValidRootForHeight(&differentMerkleRootHash, 100)
+	isValid, err := woc.IsValidRootForHeight(context.Background(), &differentMerkleRootHash, 100)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/transaction/merklepath.go
+++ b/transaction/merklepath.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -263,20 +264,20 @@ func (mp *MerklePath) ComputeRoot(txid *chainhash.Hash) (*chainhash.Hash, error)
 
 // Verify checks if a given transaction ID is part of the Merkle tree
 // at the specified block height using a chain tracker
-func (mp *MerklePath) VerifyHex(txidStr string, ct chaintracker.ChainTracker) (bool, error) {
+func (mp *MerklePath) VerifyHex(ctx context.Context, txidStr string, ct chaintracker.ChainTracker) (bool, error) {
 	if txid, err := chainhash.NewHashFromHex(txidStr); err != nil {
 		return false, err
 	} else {
-		return mp.Verify(txid, ct)
+		return mp.Verify(ctx, txid, ct)
 	}
 }
 
-func (mp *MerklePath) Verify(txid *chainhash.Hash, ct chaintracker.ChainTracker) (bool, error) {
+func (mp *MerklePath) Verify(ctx context.Context, txid *chainhash.Hash, ct chaintracker.ChainTracker) (bool, error) {
 	root, err := mp.ComputeRoot(txid)
 	if err != nil {
 		return false, err
 	}
-	return ct.IsValidRootForHeight(root, mp.BlockHeight)
+	return ct.IsValidRootForHeight(ctx, root, mp.BlockHeight)
 }
 
 func (m *MerklePath) Combine(other *MerklePath) (err error) {

--- a/transaction/merklepath_test.go
+++ b/transaction/merklepath_test.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"testing"
@@ -96,7 +97,7 @@ func TestMerklePathComputeRootHex(t *testing.T) {
 type MyChainTracker struct{}
 
 // Implement the IsValidRootForHeight method on MyChainTracker.
-func (mct MyChainTracker) IsValidRootForHeight(root *chainhash.Hash, height uint32) (bool, error) {
+func (mct MyChainTracker) IsValidRootForHeight(ctx context.Context, root *chainhash.Hash, height uint32) (bool, error) {
 	// Convert BRC74Root hex string to a byte slice for comparison
 	// expectedRoot, _ := hex.DecodeString(BRC74Root)
 
@@ -113,7 +114,7 @@ func TestMerklePath_Verify(t *testing.T) {
 			Path:        BRC74JSON.Path,
 		}
 		tracker := MyChainTracker{}
-		result, err := path.VerifyHex(BRC74TXID1, tracker)
+		result, err := path.VerifyHex(context.Background(), BRC74TXID1, tracker)
 		require.NoError(t, err)
 		require.True(t, result)
 	})


### PR DESCRIPTION
## Summary
Adds `context.Context` parameter to `ChainTracker.IsValidRootForHeight` method to enable proper cancellation and timeout support for API calls.

## Changes
- Updated ChainTracker interface to include context parameter
- Updated all implementations (WhatsOnChain, headers_client, mocks)
- Updated all callers (MerklePath, BEEF, SPV verification)
- Updated tests and examples

## Breaking Change
This is a breaking change that requires callers to pass context when using ChainTracker methods. Enables better control over HTTP request timeouts and cancellation.