### PR TITLE
Release 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Table of Contents
 
+- [1.2.7 - 2025-08-05](#127---2025-08-05)
 - [1.2.6 - 2025-07-21](#126---2025-07-21)
 - [1.2.5 - 2025-07-16](#125---2025-07-16)
 - [1.2.4 - 2025-06-30](#124---2025-06-30)
@@ -40,6 +41,36 @@ All notable changes to this project will be documented in this file. The format 
 - [1.1.1 - 2024-08-28](#111---2024-08-28)
 - [1.1.0 - 2024-08-19](#110---2024-08-19)
 - [1.0.0 - 2024-06-06](#100---2024-06-06)
+
+## [1.2.7] - 2025-08-05
+
+### Added
+- Implemented `RevealCounterpartyKeyLinkage` and `RevealSpecificKeyLinkage` methods in ProtoWallet (#219)
+- Added Schnorr zero-knowledge proof primitive in `primitives/schnorr` package
+- Added BRC-2 and BRC-3 compliance test vectors
+- Added `TestWallet` implementation for testing with comprehensive certificate management
+- Added `WalletKeys` interface and implementation for standardized key operations
+- Added test certificate manager in `wallet/testcertificates` package
+- Added `NewPrivateKeyFromInt` method to create private keys from integer values
+- Added `Pad` method to SymmetricKey for zero-padding keys to 32 bytes
+
+### Changed
+- Updated `RevealSpecificSecret` in KeyDeriver to use compressed shared secret for HMAC computation
+- Standardized proof serialization format to use compressed points (98 bytes total)
+- Improved auth fetch process to prevent hanging and fix certificate exchange between peers (#217, #220)
+- Refactored certificate validation logic with enhanced error handling
+- Updated SonarQube scan action from v5.2.0 to v5.3.0 (#216)
+- Enhanced `SimplifiedHTTPTransport` with better context handling and error management
+- Improved peer authentication handshake process with better certificate handling
+
+### Fixed
+- Fixed auth fetch hanging process during initial handshake
+- Fixed certificate exchange issues between peers
+- Fixed certificate validation edge cases and improved test coverage
+- Fixed session manager context cancellation handling
+
+### Removed
+- Removed `MockWallet` implementation in favor of `TestWallet`
 
 ## [1.2.6] - 2025-07-21
 

--- a/primitives/schnorr/schnorr.go
+++ b/primitives/schnorr/schnorr.go
@@ -1,0 +1,122 @@
+package schnorr
+
+import (
+	"math/big"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	hash "github.com/bsv-blockchain/go-sdk/primitives/hash"
+)
+
+// Proof represents a Schnorr zero-knowledge proof
+type Proof struct {
+	R      *ec.PublicKey
+	SPrime *ec.PublicKey
+	Z      *big.Int
+}
+
+// Schnorr provides methods to generate and verify proofs that demonstrate knowledge
+// of a secret without revealing it. Specifically, it allows one party to prove to
+// another that they know the private key corresponding to a public key and have
+// correctly computed a shared secret.
+type Schnorr struct{}
+
+// New creates a new Schnorr instance
+func New() *Schnorr {
+	return &Schnorr{}
+}
+
+// GenerateProof generates a proof that demonstrates the link between public key A and shared secret S
+// Parameters:
+//   - a: Private key corresponding to public key A
+//   - A: Public key of the prover
+//   - B: Other party's public key
+//   - S: Shared secret (should be B multiplied by a)
+//
+// Returns a proof (R, S', z) that can be verified without revealing the private key
+func (s *Schnorr) GenerateProof(a *ec.PrivateKey, A *ec.PublicKey, B *ec.PublicKey, S *ec.PublicKey) (*Proof, error) {
+	// Generate random value r
+	r, err := ec.NewPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate R = r*G (where G is the generator point)
+	R := r.PubKey()
+
+	// Calculate S' = r*B
+	SPrime := B.Mul(r.D)
+
+	// Compute challenge e = H(A || B || S || S' || R)
+	e := s.computeChallenge(A, B, S, SPrime, R)
+
+	// Calculate z = r + e*a (mod n)
+	z := new(big.Int).Set(r.D)
+	ea := new(big.Int).Mul(e, a.D)
+	z.Add(z, ea)
+	z.Mod(z, ec.S256().Params().N)
+
+	return &Proof{
+		R:      R,
+		SPrime: SPrime,
+		Z:      z,
+	}, nil
+}
+
+// VerifyProof verifies the proof of the link between public key A and shared secret S
+// Parameters:
+//   - A: Public key of the prover
+//   - B: Other party's public key
+//   - S: Shared secret
+//   - proof: The proof to verify
+//
+// Returns true if the proof is valid, false otherwise
+func (s *Schnorr) VerifyProof(A *ec.PublicKey, B *ec.PublicKey, S *ec.PublicKey, proof *Proof) bool {
+	// Compute challenge e = H(A || B || S || S' || R)
+	e := s.computeChallenge(A, B, S, proof.SPrime, proof.R)
+
+	// Check z*G = R + e*A
+	curve := ec.S256()
+	zGx, zGy := curve.ScalarBaseMult(proof.Z.Bytes())
+	zG := &ec.PublicKey{Curve: curve, X: zGx, Y: zGy}
+	eA := A.Mul(e)
+	RpluseA := new(ec.PublicKey)
+	RpluseA.Curve = curve
+	RpluseA.X, RpluseA.Y = curve.Add(proof.R.X, proof.R.Y, eA.X, eA.Y)
+
+	if zG.X.Cmp(RpluseA.X) != 0 || zG.Y.Cmp(RpluseA.Y) != 0 {
+		return false
+	}
+
+	// Check z*B = S' + e*S
+	zB := B.Mul(proof.Z)
+	eS := S.Mul(e)
+	SprimepluseS := new(ec.PublicKey)
+	SprimepluseS.Curve = curve
+	SprimepluseS.X, SprimepluseS.Y = curve.Add(proof.SPrime.X, proof.SPrime.Y, eS.X, eS.Y)
+
+	if zB.X.Cmp(SprimepluseS.X) != 0 || zB.Y.Cmp(SprimepluseS.Y) != 0 {
+		return false
+	}
+
+	return true
+}
+
+// computeChallenge computes the challenge value e = H(A || B || S || S' || R)
+func (s *Schnorr) computeChallenge(A, B, S, SPrime, R *ec.PublicKey) *big.Int {
+	// Concatenate all points in compressed format
+	message := make([]byte, 0, 33*5)
+	message = append(message, A.Compressed()...)
+	message = append(message, B.Compressed()...)
+	message = append(message, S.Compressed()...)
+	message = append(message, SPrime.Compressed()...)
+	message = append(message, R.Compressed()...)
+
+	// Hash the concatenated points
+	h := hash.Sha256(message)
+
+	// Convert hash to big.Int and reduce modulo curve order
+	e := new(big.Int).SetBytes(h)
+	e.Mod(e, ec.S256().Params().N)
+
+	return e
+}

--- a/primitives/schnorr/schnorr_test.go
+++ b/primitives/schnorr/schnorr_test.go
@@ -1,0 +1,224 @@
+package schnorr
+
+import (
+	"math/big"
+	"testing"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchnorr_GenerateAndVerifyProof(t *testing.T) {
+	s := New()
+
+	// Generate private keys
+	a, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	b, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Get public keys
+	A := a.PubKey()
+	B := b.PubKey()
+
+	// Calculate shared secret S = B * a = A * b
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+	require.NotNil(t, proof)
+	require.NotNil(t, proof.R)
+	require.NotNil(t, proof.SPrime)
+	require.NotNil(t, proof.Z)
+
+	// Verify proof
+	result := s.VerifyProof(A, B, S, proof)
+	assert.True(t, result, "Valid proof should verify successfully")
+}
+
+func TestSchnorr_FailVerificationWithTamperedR(t *testing.T) {
+	s := New()
+
+	// Generate keys and shared secret
+	a, _ := ec.NewPrivateKey()
+	b, _ := ec.NewPrivateKey()
+	A := a.PubKey()
+	B := b.PubKey()
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Tamper with R by adding the generator point
+	curve := A.Curve
+	tamperedR := new(ec.PublicKey)
+	tamperedR.Curve = curve
+	tamperedR.X, tamperedR.Y = curve.Add(proof.R.X, proof.R.Y, curve.Params().Gx, curve.Params().Gy)
+	tamperedProof := &Proof{
+		R:      tamperedR,
+		SPrime: proof.SPrime,
+		Z:      proof.Z,
+	}
+
+	// Verify should fail
+	result := s.VerifyProof(A, B, S, tamperedProof)
+	assert.False(t, result, "Tampered proof should fail verification")
+}
+
+func TestSchnorr_FailVerificationWithTamperedZ(t *testing.T) {
+	s := New()
+
+	// Generate keys and shared secret
+	a, _ := ec.NewPrivateKey()
+	b, _ := ec.NewPrivateKey()
+	A := a.PubKey()
+	B := b.PubKey()
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Tamper with z
+	tamperedZ := new(big.Int).Add(proof.Z, big.NewInt(1))
+	tamperedZ.Mod(tamperedZ, A.Curve.Params().N)
+	tamperedProof := &Proof{
+		R:      proof.R,
+		SPrime: proof.SPrime,
+		Z:      tamperedZ,
+	}
+
+	// Verify should fail
+	result := s.VerifyProof(A, B, S, tamperedProof)
+	assert.False(t, result, "Tampered proof should fail verification")
+}
+
+func TestSchnorr_FailVerificationWithTamperedSPrime(t *testing.T) {
+	s := New()
+
+	// Generate keys and shared secret
+	a, _ := ec.NewPrivateKey()
+	b, _ := ec.NewPrivateKey()
+	A := a.PubKey()
+	B := b.PubKey()
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Tamper with S'
+	curve := A.Curve
+	tamperedSPrime := new(ec.PublicKey)
+	tamperedSPrime.Curve = curve
+	tamperedSPrime.X, tamperedSPrime.Y = curve.Add(proof.SPrime.X, proof.SPrime.Y, curve.Params().Gx, curve.Params().Gy)
+	tamperedProof := &Proof{
+		R:      proof.R,
+		SPrime: tamperedSPrime,
+		Z:      proof.Z,
+	}
+
+	// Verify should fail
+	result := s.VerifyProof(A, B, S, tamperedProof)
+	assert.False(t, result, "Tampered proof should fail verification")
+}
+
+func TestSchnorr_FailVerificationWithWrongPublicKey(t *testing.T) {
+	s := New()
+
+	// Generate keys and shared secret
+	a, _ := ec.NewPrivateKey()
+	b, _ := ec.NewPrivateKey()
+	A := a.PubKey()
+	B := b.PubKey()
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Use wrong public key for verification
+	wrongA, _ := ec.NewPrivateKey()
+	wrongAPublic := wrongA.PubKey()
+
+	// Verify should fail
+	result := s.VerifyProof(wrongAPublic, B, S, proof)
+	assert.False(t, result, "Wrong public key should fail verification")
+}
+
+func TestSchnorr_FailVerificationWithWrongSharedSecret(t *testing.T) {
+	s := New()
+
+	// Generate keys and shared secret
+	a, _ := ec.NewPrivateKey()
+	b, _ := ec.NewPrivateKey()
+	A := a.PubKey()
+	B := b.PubKey()
+	S := B.Mul(a.D)
+
+	// Generate proof with correct S
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Create wrong shared secret
+	c, _ := ec.NewPrivateKey()
+	wrongS := B.Mul(c.D)
+
+	// Verify should fail
+	result := s.VerifyProof(A, B, wrongS, proof)
+	assert.False(t, result, "Wrong shared secret should fail verification")
+}
+
+func TestSchnorr_VerifyWithFixedKeys(t *testing.T) {
+	s := New()
+
+	// Use fixed private keys for determinism (matching TypeScript test)
+	a, err := ec.PrivateKeyFromHex("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	require.NoError(t, err)
+	
+	b, err := ec.PrivateKeyFromHex("fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321")
+	require.NoError(t, err)
+
+	// Get public keys
+	A := a.PubKey()
+	B := b.PubKey()
+
+	// Calculate shared secret
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Verify proof
+	result := s.VerifyProof(A, B, S, proof)
+	assert.True(t, result, "Fixed key proof should verify successfully")
+}
+
+func TestSchnorr_ProofComponentsNotNil(t *testing.T) {
+	s := New()
+
+	// Generate random keys
+	a, _ := ec.NewPrivateKey()
+	b, _ := ec.NewPrivateKey()
+	A := a.PubKey()
+	B := b.PubKey()
+	S := B.Mul(a.D)
+
+	// Generate proof
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+
+	// Check all components are present
+	assert.NotNil(t, proof.R)
+	assert.NotNil(t, proof.R.X)
+	assert.NotNil(t, proof.R.Y)
+	assert.NotNil(t, proof.SPrime)
+	assert.NotNil(t, proof.SPrime.X)
+	assert.NotNil(t, proof.SPrime.Y)
+	assert.NotNil(t, proof.Z)
+	assert.Greater(t, proof.Z.BitLen(), 0, "Z should not be zero")
+}

--- a/wallet/completed_proto_wallet.go
+++ b/wallet/completed_proto_wallet.go
@@ -102,11 +102,11 @@ func (c *CompletedProtoWallet) RelinquishOutput(ctx context.Context, args Relinq
 }
 
 func (c *CompletedProtoWallet) RevealCounterpartyKeyLinkage(ctx context.Context, args RevealCounterpartyKeyLinkageArgs, originator string) (*RevealCounterpartyKeyLinkageResult, error) {
-	return nil, nil
+	return c.ProtoWallet.RevealCounterpartyKeyLinkage(ctx, args, originator)
 }
 
 func (c *CompletedProtoWallet) RevealSpecificKeyLinkage(ctx context.Context, args RevealSpecificKeyLinkageArgs, originator string) (*RevealSpecificKeyLinkageResult, error) {
-	return nil, nil
+	return c.ProtoWallet.RevealSpecificKeyLinkage(ctx, args, originator)
 }
 
 func (c *CompletedProtoWallet) RelinquishCertificate(ctx context.Context, args RelinquishCertificateArgs, originator string) (*RelinquishCertificateResult, error) {

--- a/wallet/key_deriver.go
+++ b/wallet/key_deriver.go
@@ -162,8 +162,8 @@ func (kd *KeyDeriver) RevealSpecificSecret(counterparty Counterparty, protocol P
 		return nil, fmt.Errorf("failed to compute invoice number: %w", err)
 	}
 
-	// Compute HMAC-SHA256 of shared secret and invoice number
-	mac := hmac.New(sha256.New, sharedSecret.X.Bytes())
+	// Compute HMAC-SHA256 using compressed shared secret as key
+	mac := hmac.New(sha256.New, sharedSecret.Compressed())
 	mac.Write([]byte(invoiceNumber))
 	return mac.Sum(nil), nil
 }

--- a/wallet/key_deriver_test.go
+++ b/wallet/key_deriver_test.go
@@ -207,7 +207,7 @@ func TestKeyDeriver(t *testing.T) {
 		invoiceNumber, err := keyDeriver.computeInvoiceNumber(protocolID, keyID)
 		assert.NoError(t, err, "computing invoice number for verification should not error")
 
-		mac := hmac.New(sha256.New, sharedSecret.X.Bytes())
+		mac := hmac.New(sha256.New, sharedSecret.Compressed())
 		mac.Write([]byte(invoiceNumber))
 		expected := mac.Sum(nil)
 

--- a/wallet/proto_wallet_brc_test.go
+++ b/wallet/proto_wallet_brc_test.go
@@ -1,0 +1,212 @@
+package wallet
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/primitives/schnorr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProtoWallet_BRC2_EncryptionVector tests BRC-2 encryption compliance
+func TestProtoWallet_BRC2_EncryptionVector(t *testing.T) {
+	ctx := context.Background()
+
+	// BRC-2 Encryption Compliance Vector
+	privateKeyHex := "6a2991c9de20e38b31d7ea147bf55f5039e4bbc073160f5e0d541d1f17e321b8"
+	privateKey, err := ec.PrivateKeyFromHex(privateKeyHex)
+	require.NoError(t, err)
+
+	counterpartyPubKeyHex := "0294c479f762f6baa97fbcd4393564c1d7bd8336ebd15928135bbcf575cd1a71a1"
+	counterpartyPubKeyBytes, err := hex.DecodeString(counterpartyPubKeyHex)
+	require.NoError(t, err)
+	counterpartyPubKey, err := ec.PublicKeyFromBytes(counterpartyPubKeyBytes)
+	require.NoError(t, err)
+
+	protoWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: privateKey,
+	})
+	require.NoError(t, err)
+
+	// Expected ciphertext
+	expectedCiphertext := []byte{252, 203, 216, 184, 29, 161, 223, 212, 16, 193, 94, 99, 31, 140, 99, 43, 61, 236, 184, 67, 54, 105, 199, 47, 11, 19, 184, 127, 2, 165, 125, 9, 188, 195, 196, 39, 120, 130, 213, 95, 186, 89, 64, 28, 1, 80, 20, 213, 159, 133, 98, 253, 128, 105, 113, 247, 197, 152, 236, 64, 166, 207, 113, 134, 65, 38, 58, 24, 127, 145, 140, 206, 47, 70, 146, 84, 186, 72, 95, 35, 154, 112, 178, 55, 72, 124}
+	plaintext := "BRC-2 Encryption Compliance Validated!"
+
+	// Decrypt the ciphertext
+	decryptResult, err := protoWallet.Decrypt(ctx, DecryptArgs{
+		Ciphertext: expectedCiphertext,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "BRC2 Test"},
+			KeyID:        "42",
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyPubKey},
+		},
+	}, "test")
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, string(decryptResult.Plaintext))
+}
+
+// TestProtoWallet_BRC2_HMACVector tests BRC-2 HMAC compliance
+func TestProtoWallet_BRC2_HMACVector(t *testing.T) {
+	ctx := context.Background()
+
+	// BRC-2 HMAC Compliance Vector
+	privateKeyHex := "6a2991c9de20e38b31d7ea147bf55f5039e4bbc073160f5e0d541d1f17e321b8"
+	privateKey, err := ec.PrivateKeyFromHex(privateKeyHex)
+	require.NoError(t, err)
+
+	counterpartyPubKeyHex := "0294c479f762f6baa97fbcd4393564c1d7bd8336ebd15928135bbcf575cd1a71a1"
+	counterpartyPubKeyBytes, err := hex.DecodeString(counterpartyPubKeyHex)
+	require.NoError(t, err)
+	counterpartyPubKey, err := ec.PublicKeyFromBytes(counterpartyPubKeyBytes)
+	require.NoError(t, err)
+
+	protoWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: privateKey,
+	})
+	require.NoError(t, err)
+
+	// Create HMAC
+	data := []byte("BRC-2 HMAC Compliance Validated!")
+	hmacResult, err := protoWallet.CreateHMAC(ctx, CreateHMACArgs{
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "BRC2 Test"},
+			KeyID:        "42",
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyPubKey},
+		},
+		Data: data,
+	}, "test")
+	require.NoError(t, err)
+
+	// Expected HMAC
+	expectedHMAC := []byte{81, 240, 18, 153, 163, 45, 174, 85, 9, 246, 142, 125, 209, 133, 82, 76, 254, 103, 46, 182, 86, 59, 219, 61, 126, 30, 176, 232, 233, 100, 234, 14}
+	assert.Equal(t, expectedHMAC, hmacResult.HMAC[:])
+}
+
+// TestProtoWallet_BRC3_SignatureVector tests BRC-3 signature compliance
+func TestProtoWallet_BRC3_SignatureVector(t *testing.T) {
+	ctx := context.Background()
+
+	// Note: We can't reproduce the exact signature due to randomness in ECDSA,
+	// but we can verify that our signatures are valid
+
+	// Use a fixed private key for testing
+	privateKeyHex := "6a2991c9de20e38b31d7ea147bf55f5039e4bbc073160f5e0d541d1f17e321b8"
+	privateKey, err := ec.PrivateKeyFromHex(privateKeyHex)
+	require.NoError(t, err)
+
+	counterpartyPubKeyHex := "0294c479f762f6baa97fbcd4393564c1d7bd8336ebd15928135bbcf575cd1a71a1"
+	counterpartyPubKeyBytes, err := hex.DecodeString(counterpartyPubKeyHex)
+	require.NoError(t, err)
+	counterpartyPubKey, err := ec.PublicKeyFromBytes(counterpartyPubKeyBytes)
+	require.NoError(t, err)
+
+	protoWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: privateKey,
+	})
+	require.NoError(t, err)
+
+	// Create a signature
+	data := []byte("BRC-3 Compliance Validated!")
+	sigResult, err := protoWallet.CreateSignature(ctx, CreateSignatureArgs{
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "BRC3 Test"},
+			KeyID:        "42",
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyPubKey},
+		},
+		Data: data,
+	}, "test")
+	require.NoError(t, err)
+
+	// Verify our own signature works
+	forSelf := true
+	verifyResult, err := protoWallet.VerifySignature(ctx, VerifySignatureArgs{
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "BRC3 Test"},
+			KeyID:        "42",
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyPubKey},
+		},
+		Data:      data,
+		Signature: sigResult.Signature,
+		ForSelf:   &forSelf,
+	}, "test")
+	require.NoError(t, err)
+	assert.True(t, verifyResult.Valid)
+}
+
+// TestKeyDeriver_FixedTestVectors tests key derivation with fixed values
+func TestKeyDeriver_FixedTestVectors(t *testing.T) {
+	// Create keys with fixed values
+	// Create a 32-byte array with value 42
+	rootKeyBytes := make([]byte, 32)
+	rootKeyBytes[31] = 42
+	rootPrivateKey, _ := ec.PrivateKeyFromBytes(rootKeyBytes)
+	
+	// Create a 32-byte array with value 69
+	counterpartyKeyBytes := make([]byte, 32)
+	counterpartyKeyBytes[31] = 69
+	counterpartyPrivateKey, _ := ec.PrivateKeyFromBytes(counterpartyKeyBytes)
+	counterpartyPublicKey := counterpartyPrivateKey.PubKey()
+
+	kd := NewKeyDeriver(rootPrivateKey)
+
+	// Test invoice number computation
+	protocolID := Protocol{SecurityLevel: 0, Protocol: "testprotocol"}
+	keyID := "12345"
+	
+	invoiceNumber, err := kd.computeInvoiceNumber(protocolID, keyID)
+	require.NoError(t, err)
+	assert.Equal(t, "0-testprotocol-12345", invoiceNumber)
+
+	// Test public key derivation
+	pubKey, err := kd.DerivePublicKey(protocolID, keyID, Counterparty{
+		Type:         CounterpartyTypeOther,
+		Counterparty: counterpartyPublicKey,
+	}, false)
+	require.NoError(t, err)
+	assert.NotNil(t, pubKey)
+
+	// Test private key derivation
+	privKey, err := kd.DerivePrivateKey(protocolID, keyID, Counterparty{
+		Type:         CounterpartyTypeOther,
+		Counterparty: counterpartyPublicKey,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, privKey)
+}
+
+// TestSchnorr_FixedKeyVector tests Schnorr proof with fixed keys
+func TestSchnorr_FixedKeyVector(t *testing.T) {
+	// Fixed keys for deterministic testing
+	aHex := "0000000000000000000000000000000123456789abcdef123456789abcdef123456789abcdef123456789abcdef"
+	bHex := "00000000000000000000000000000000abcdef123456789abcdef123456789abcdef123456789abcdef123456789"
+	
+	// Note: The hex strings above are longer than 32 bytes, so we'll use the last 32 bytes
+	aBytes, err := hex.DecodeString(aHex[len(aHex)-64:])
+	require.NoError(t, err)
+	a, _ := ec.PrivateKeyFromBytes(aBytes)
+	
+	bBytes, err := hex.DecodeString(bHex[len(bHex)-64:])
+	require.NoError(t, err)
+	b, _ := ec.PrivateKeyFromBytes(bBytes)
+	
+	A := a.PubKey()
+	B := b.PubKey()
+	
+	// Compute shared secret
+	S, err := a.DeriveSharedSecret(B)
+	require.NoError(t, err)
+	
+	// Generate and verify proof
+	s := schnorr.New()
+	proof, err := s.GenerateProof(a, A, B, S)
+	require.NoError(t, err)
+	
+	valid := s.VerifyProof(A, B, S, proof)
+	assert.True(t, valid)
+}

--- a/wallet/proto_wallet_reveal.go
+++ b/wallet/proto_wallet_reveal.go
@@ -1,0 +1,206 @@
+package wallet
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/primitives/schnorr"
+)
+
+// RevealCounterpartyKeyLinkage reveals the key linkage between the wallet's identity and a counterparty.
+// This creates a cryptographic proof that can be verified by a third party.
+func (p *ProtoWallet) RevealCounterpartyKeyLinkage(
+	ctx context.Context,
+	args RevealCounterpartyKeyLinkageArgs,
+	originator string,
+) (*RevealCounterpartyKeyLinkageResult, error) {
+	// Validate inputs
+	if args.Counterparty == nil {
+		return nil, fmt.Errorf("counterparty public key is required")
+	}
+	if args.Verifier == nil {
+		return nil, fmt.Errorf("verifier public key is required")
+	}
+
+	// Get the identity key (root key)
+	identityKey := p.keyDeriver.rootKey
+	proverPublicKey := identityKey.PubKey()
+
+	// Get the shared secret (linkage) as a point
+	linkagePoint, err := p.keyDeriver.RevealCounterpartySecret(Counterparty{
+		Type:         CounterpartyTypeOther,
+		Counterparty: args.Counterparty,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to reveal counterparty secret: %v", err)
+	}
+
+	// Generate Schnorr proof
+	s := schnorr.New()
+	proof, err := s.GenerateProof(identityKey, proverPublicKey, args.Counterparty, linkagePoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate proof: %v", err)
+	}
+
+	// Serialize the proof components
+	// Format: R compressed (33 bytes) || S' compressed (33 bytes) || z (32 bytes) = 98 bytes total
+	proofBytes := make([]byte, 0, 98)
+	
+	// R point compressed
+	proofBytes = append(proofBytes, proof.R.Compressed()...)
+	
+	// S' point compressed
+	proofBytes = append(proofBytes, proof.SPrime.Compressed()...)
+	
+	// z value (32 bytes)
+	proofBytes = append(proofBytes, padTo32Bytes(proof.Z.Bytes())...)
+
+	// Create revelation time
+	revelationTime := time.Now().UTC().Format(time.RFC3339Nano)
+
+	// Convert linkage point to compressed bytes for encryption
+	linkageBytes := linkagePoint.Compressed()
+
+	// Encrypt the linkage for the verifier
+	encryptArgs := EncryptArgs{
+		Plaintext: linkageBytes,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "counterparty linkage revelation"},
+			KeyID:        revelationTime,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: args.Verifier},
+		},
+	}
+	encryptResult, err := p.Encrypt(ctx, encryptArgs, originator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt linkage: %v", err)
+	}
+
+	// Encrypt the proof for the verifier
+	encryptProofArgs := EncryptArgs{
+		Plaintext: proofBytes,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "counterparty linkage revelation"},
+			KeyID:        revelationTime,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: args.Verifier},
+		},
+	}
+	encryptProofResult, err := p.Encrypt(ctx, encryptProofArgs, originator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt proof: %v", err)
+	}
+
+	return &RevealCounterpartyKeyLinkageResult{
+		Prover:                proverPublicKey,
+		Counterparty:          args.Counterparty,
+		Verifier:              args.Verifier,
+		RevelationTime:        revelationTime,
+		EncryptedLinkage:      encryptResult.Ciphertext,
+		EncryptedLinkageProof: encryptProofResult.Ciphertext,
+	}, nil
+}
+
+// RevealSpecificKeyLinkage reveals the key linkage for a specific protocol and key ID.
+func (p *ProtoWallet) RevealSpecificKeyLinkage(
+	ctx context.Context,
+	args RevealSpecificKeyLinkageArgs,
+	originator string,
+) (*RevealSpecificKeyLinkageResult, error) {
+	// Validate inputs
+	if args.Verifier == nil {
+		return nil, fmt.Errorf("verifier public key is required")
+	}
+
+	// Get the identity key (root key)
+	identityKey := p.keyDeriver.rootKey
+	proverPublicKey := identityKey.PubKey()
+
+	// Validate counterparty
+	counterpartyPubKey, err := getCounterpartyPublicKey(args.Counterparty)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the specific secret (linkage)
+	linkage, err := p.keyDeriver.RevealSpecificSecret(args.Counterparty, args.ProtocolID, args.KeyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reveal specific secret: %v", err)
+	}
+
+	// For specific key linkage, we use proof type 0 (no proof)
+	// Just a single byte array [0]
+	proofBytes := []byte{0}
+
+	// Create the special protocol ID for specific linkage revelation
+	encryptProtocolID := Protocol{
+		SecurityLevel: 2,
+		Protocol:      fmt.Sprintf("specific linkage revelation %d %s", args.ProtocolID.SecurityLevel, args.ProtocolID.Protocol),
+	}
+
+	// Encrypt the linkage for the verifier
+	encryptArgs := EncryptArgs{
+		Plaintext: linkage,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   encryptProtocolID,
+			KeyID:        args.KeyID,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: args.Verifier},
+		},
+	}
+	encryptResult, err := p.Encrypt(ctx, encryptArgs, originator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt linkage: %v", err)
+	}
+
+	// Encrypt the proof for the verifier
+	encryptProofArgs := EncryptArgs{
+		Plaintext: proofBytes,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   encryptProtocolID,
+			KeyID:        args.KeyID,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: args.Verifier},
+		},
+	}
+	encryptProofResult, err := p.Encrypt(ctx, encryptProofArgs, originator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt proof: %v", err)
+	}
+
+	return &RevealSpecificKeyLinkageResult{
+		EncryptedLinkage:      encryptResult.Ciphertext,
+		EncryptedLinkageProof: encryptProofResult.Ciphertext,
+		Prover:                proverPublicKey,
+		Verifier:              args.Verifier,
+		Counterparty:          counterpartyPubKey,
+		ProtocolID:            args.ProtocolID,
+		KeyID:                 args.KeyID,
+		ProofType:             0, // No proof for specific linkage
+	}, nil
+}
+
+// padTo32Bytes pads a byte slice to 32 bytes with leading zeros
+func padTo32Bytes(b []byte) []byte {
+	if len(b) >= 32 {
+		return b[:32]
+	}
+	padded := make([]byte, 32)
+	copy(padded[32-len(b):], b)
+	return padded
+}
+
+// getCounterpartyPublicKey converts a Counterparty to a PublicKey
+func getCounterpartyPublicKey(counterparty Counterparty) (*ec.PublicKey, error) {
+	switch counterparty.Type {
+	case CounterpartyTypeSelf:
+		return nil, fmt.Errorf("cannot reveal specific key linkage for 'self'")
+	case CounterpartyTypeAnyone:
+		return nil, fmt.Errorf("cannot reveal specific key linkage for 'anyone'")
+	case CounterpartyTypeOther:
+		if counterparty.Counterparty == nil {
+			return nil, fmt.Errorf("counterparty public key is required")
+		}
+		return counterparty.Counterparty, nil
+	default:
+		return nil, fmt.Errorf("invalid counterparty type: %v", counterparty.Type)
+	}
+}

--- a/wallet/proto_wallet_reveal_test.go
+++ b/wallet/proto_wallet_reveal_test.go
@@ -1,0 +1,328 @@
+package wallet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/primitives/schnorr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtoWallet_RevealCounterpartyKeyLinkage(t *testing.T) {
+	ctx := context.Background()
+	
+	// Initialize keys
+	proverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	counterpartyKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Initialize wallets
+	proverWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: proverKey,
+	})
+	require.NoError(t, err)
+
+	verifierWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: verifierKey,
+	})
+	require.NoError(t, err)
+
+	// Prover reveals counterparty key linkage
+	revelation, err := proverWallet.RevealCounterpartyKeyLinkage(ctx, RevealCounterpartyKeyLinkageArgs{
+		Counterparty: counterpartyKey.PubKey(),
+		Verifier:     verifierKey.PubKey(),
+	}, "test")
+	require.NoError(t, err)
+	require.NotNil(t, revelation)
+
+	// Verify fields
+	assert.NotNil(t, revelation.Prover)
+	assert.Equal(t, proverKey.PubKey(), revelation.Prover)
+	assert.Equal(t, counterpartyKey.PubKey(), revelation.Counterparty)
+	assert.Equal(t, verifierKey.PubKey(), revelation.Verifier)
+	assert.NotEmpty(t, revelation.RevelationTime)
+	assert.NotEmpty(t, revelation.EncryptedLinkage)
+	assert.NotEmpty(t, revelation.EncryptedLinkageProof)
+
+	// Parse time to ensure it's valid RFC3339
+	_, err = time.Parse(time.RFC3339Nano, revelation.RevelationTime)
+	require.NoError(t, err)
+
+	// Verifier decrypts the encrypted linkage
+	decryptResult, err := verifierWallet.Decrypt(ctx, DecryptArgs{
+		Ciphertext: revelation.EncryptedLinkage,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "counterparty linkage revelation"},
+			KeyID:        revelation.RevelationTime,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: proverKey.PubKey()},
+		},
+	}, "test")
+	require.NoError(t, err)
+	// Compute expected linkage
+	expectedSharedSecret, err := proverKey.DeriveSharedSecret(counterpartyKey.PubKey())
+	require.NoError(t, err)
+	expectedLinkage := expectedSharedSecret.Compressed()
+
+	// Compare linkage
+	assert.Equal(t, expectedLinkage, []byte(decryptResult.Plaintext))
+
+	// Decrypt and verify the proof
+	decryptProofResult, err := verifierWallet.Decrypt(ctx, DecryptArgs{
+		Ciphertext: revelation.EncryptedLinkageProof,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID:   Protocol{SecurityLevel: 2, Protocol: "counterparty linkage revelation"},
+			KeyID:        revelation.RevelationTime,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: proverKey.PubKey()},
+		},
+	}, "test")
+	require.NoError(t, err)
+	// Verify proof format (should be 98 bytes: 33 + 33 + 32)
+	assert.Equal(t, 98, len(decryptProofResult.Plaintext))
+
+	// Proof components: R compressed (33 bytes) || S' compressed (33 bytes) || z (32 bytes)
+}
+
+func TestProtoWallet_RevealSpecificKeyLinkage(t *testing.T) {
+	ctx := context.Background()
+	
+	// Initialize keys
+	proverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	counterpartyKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Initialize wallets
+	proverWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: proverKey,
+	})
+	require.NoError(t, err)
+
+	verifierWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: verifierKey,
+	})
+	require.NoError(t, err)
+
+	protocolID := Protocol{SecurityLevel: 0, Protocol: "tests"}
+	keyID := "test key id"
+
+	// Prover reveals specific key linkage
+	revelation, err := proverWallet.RevealSpecificKeyLinkage(ctx, RevealSpecificKeyLinkageArgs{
+		Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyKey.PubKey()},
+		Verifier:     verifierKey.PubKey(),
+		ProtocolID:   protocolID,
+		KeyID:        keyID,
+	}, "test")
+	require.NoError(t, err)
+	require.NotNil(t, revelation)
+
+	// Verify fields
+	assert.NotEmpty(t, revelation.EncryptedLinkage)
+	assert.NotEmpty(t, revelation.EncryptedLinkageProof)
+	assert.Equal(t, proverKey.PubKey(), revelation.Prover)
+	assert.Equal(t, verifierKey.PubKey(), revelation.Verifier)
+	assert.Equal(t, counterpartyKey.PubKey(), revelation.Counterparty)
+	assert.Equal(t, protocolID, revelation.ProtocolID)
+	assert.Equal(t, keyID, revelation.KeyID)
+	assert.Equal(t, byte(0), revelation.ProofType) // No proof for specific linkage
+
+	// Verifier decrypts the encrypted linkage
+	decryptResult, err := verifierWallet.Decrypt(ctx, DecryptArgs{
+		Ciphertext: revelation.EncryptedLinkage,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID: Protocol{
+				SecurityLevel: 2,
+				Protocol:      "specific linkage revelation 0 tests",
+			},
+			KeyID:        keyID,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: proverKey.PubKey()},
+		},
+	}, "test")
+	require.NoError(t, err)
+	// Compute expected linkage using KeyDeriver
+	kd := NewKeyDeriver(proverKey)
+	expectedLinkage, err := kd.RevealSpecificSecret(
+		Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyKey.PubKey()},
+		protocolID,
+		keyID,
+	)
+	require.NoError(t, err)
+
+	// Compare linkage
+	assert.Equal(t, expectedLinkage, []byte(decryptResult.Plaintext))
+
+	// Decrypt the proof
+	decryptProofResult, err := verifierWallet.Decrypt(ctx, DecryptArgs{
+		Ciphertext: revelation.EncryptedLinkageProof,
+		EncryptionArgs: EncryptionArgs{
+			ProtocolID: Protocol{
+				SecurityLevel: 2,
+				Protocol:      "specific linkage revelation 0 tests",
+			},
+			KeyID:        keyID,
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: proverKey.PubKey()},
+		},
+	}, "test")
+	require.NoError(t, err)
+	// Verify proof is just [0]
+	assert.Equal(t, []byte{0}, []byte(decryptProofResult.Plaintext))
+}
+
+func TestProtoWallet_RevealCounterpartyKeyLinkage_Errors(t *testing.T) {
+	ctx := context.Background()
+	
+	proverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	
+	proverWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: proverKey,
+	})
+	require.NoError(t, err)
+
+	// Test with nil counterparty
+	_, err = proverWallet.RevealCounterpartyKeyLinkage(ctx, RevealCounterpartyKeyLinkageArgs{
+		Counterparty: nil,
+		Verifier:     proverKey.PubKey(),
+	}, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "counterparty public key is required")
+
+	// Test with nil verifier
+	_, err = proverWallet.RevealCounterpartyKeyLinkage(ctx, RevealCounterpartyKeyLinkageArgs{
+		Counterparty: proverKey.PubKey(),
+		Verifier:     nil,
+	}, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "verifier public key is required")
+}
+
+func TestProtoWallet_RevealSpecificKeyLinkage_Errors(t *testing.T) {
+	ctx := context.Background()
+	
+	proverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	
+	proverWallet, err := NewProtoWallet(ProtoWalletArgs{
+		Type:       ProtoWalletArgsTypePrivateKey,
+		PrivateKey: proverKey,
+	})
+	require.NoError(t, err)
+
+	// Test with nil verifier
+	_, err = proverWallet.RevealSpecificKeyLinkage(ctx, RevealSpecificKeyLinkageArgs{
+		Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: proverKey.PubKey()},
+		Verifier:     nil,
+		ProtocolID:   Protocol{SecurityLevel: 0, Protocol: "test"},
+		KeyID:        "test",
+	}, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "verifier public key is required")
+
+	// Test with "self" counterparty
+	_, err = proverWallet.RevealSpecificKeyLinkage(ctx, RevealSpecificKeyLinkageArgs{
+		Counterparty: Counterparty{Type: CounterpartyTypeSelf},
+		Verifier:     proverKey.PubKey(),
+		ProtocolID:   Protocol{SecurityLevel: 0, Protocol: "test"},
+		KeyID:        "test",
+	}, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot reveal specific key linkage for 'self'")
+
+	// Test with "anyone" counterparty
+	_, err = proverWallet.RevealSpecificKeyLinkage(ctx, RevealSpecificKeyLinkageArgs{
+		Counterparty: Counterparty{Type: CounterpartyTypeAnyone},
+		Verifier:     proverKey.PubKey(),
+		ProtocolID:   Protocol{SecurityLevel: 0, Protocol: "test"},
+		KeyID:        "test",
+	}, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot reveal specific key linkage for 'anyone'")
+}
+
+func TestSchnorrProofIntegration(t *testing.T) {
+	// This test verifies that the Schnorr proof generated in RevealCounterpartyKeyLinkage
+	// can be verified independently
+
+	// Create keys
+	proverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	counterpartyKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Compute shared secret
+	sharedSecret, err := proverKey.DeriveSharedSecret(counterpartyKey.PubKey())
+	require.NoError(t, err)
+
+	// Generate Schnorr proof
+	s := schnorr.New()
+	proof, err := s.GenerateProof(proverKey, proverKey.PubKey(), counterpartyKey.PubKey(), sharedSecret)
+	require.NoError(t, err)
+
+	// Verify proof
+	valid := s.VerifyProof(proverKey.PubKey(), counterpartyKey.PubKey(), sharedSecret, proof)
+	assert.True(t, valid)
+}
+
+func TestCompletedProtoWallet_RevealMethods(t *testing.T) {
+	ctx := context.Background()
+	
+	// Create keys
+	proverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	counterpartyKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	
+	// Create CompletedProtoWallet
+	wallet, err := NewCompletedProtoWallet(proverKey)
+	require.NoError(t, err)
+	
+	t.Run("RevealCounterpartyKeyLinkage delegates correctly", func(t *testing.T) {
+		result, err := wallet.RevealCounterpartyKeyLinkage(ctx, RevealCounterpartyKeyLinkageArgs{
+			Counterparty: counterpartyKey.PubKey(),
+			Verifier:     verifierKey.PubKey(),
+		}, "test")
+		
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, proverKey.PubKey(), result.Prover)
+		assert.Equal(t, counterpartyKey.PubKey(), result.Counterparty)
+		assert.Equal(t, verifierKey.PubKey(), result.Verifier)
+		assert.NotEmpty(t, result.EncryptedLinkage)
+		assert.NotEmpty(t, result.EncryptedLinkageProof)
+		assert.NotEmpty(t, result.RevelationTime)
+	})
+	
+	t.Run("RevealSpecificKeyLinkage delegates correctly", func(t *testing.T) {
+		result, err := wallet.RevealSpecificKeyLinkage(ctx, RevealSpecificKeyLinkageArgs{
+			Counterparty: Counterparty{Type: CounterpartyTypeOther, Counterparty: counterpartyKey.PubKey()},
+			Verifier:     verifierKey.PubKey(),
+			ProtocolID:   Protocol{SecurityLevel: 0, Protocol: "test suite"},
+			KeyID:        "test-key-id",
+		}, "test")
+		
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, proverKey.PubKey(), result.Prover)
+		assert.Equal(t, counterpartyKey.PubKey(), result.Counterparty)
+		assert.Equal(t, verifierKey.PubKey(), result.Verifier)
+		assert.NotEmpty(t, result.EncryptedLinkage)
+		assert.NotEmpty(t, result.EncryptedLinkageProof)
+		assert.Equal(t, byte(0), result.ProofType)
+		assert.Equal(t, "test suite", result.ProtocolID.Protocol)
+		assert.Equal(t, "test-key-id", result.KeyID)
+	})
+}


### PR DESCRIPTION
  This release includes significant enhancements to the ProtoWallet functionality, authentication improvements, and
  testing infrastructure updates.

  ### Highlights

  - **ProtoWallet Reveal Methods**: Implemented missing `RevealCounterpartyKeyLinkage` and
  `RevealSpecificKeyLinkage` methods (#219)
  - **Schnorr Zero-Knowledge Proofs**: Added new cryptographic primitive for proving knowledge of shared secrets
  - **Authentication Improvements**: Fixed hanging processes and improved certificate exchange between peers
  - **Improved Testing**: New TestWallet implementation with comprehensive certificate management

  ### Full Changelog

  #### Added
  - Implemented `RevealCounterpartyKeyLinkage` and `RevealSpecificKeyLinkage` methods in ProtoWallet (#219)
  - Added Schnorr zero-knowledge proof primitive in `primitives/schnorr` package
  - Added BRC-2 and BRC-3 compliance test vectors
  - Added `TestWallet` implementation for testing with comprehensive certificate management
  - Added `WalletKeys` interface and implementation for standardized key operations
  - Added test certificate manager in `wallet/testcertificates` package
  - Added `NewPrivateKeyFromInt` method to create private keys from integer values
  - Added `Pad` method to SymmetricKey for zero-padding keys to 32 bytes

  #### Changed
  - Updated `RevealSpecificSecret` in KeyDeriver to use compressed shared secret for HMAC computation
  - Standardized proof serialization format to use compressed points (98 bytes total)
  - Improved auth fetch process to prevent hanging and fix certificate exchange between peers (#217, #220)
  - Refactored certificate validation logic with enhanced error handling
  - Updated SonarQube scan action from v5.2.0 to v5.3.0 (#216)
  - Enhanced `SimplifiedHTTPTransport` with better context handling and error management
  - Improved peer authentication handshake process with better certificate handling

  #### Fixed
  - Fixed auth fetch hanging process during initial handshake
  - Fixed certificate exchange issues between peers
  - Fixed certificate validation edge cases and improved test coverage
  - Fixed session manager context cancellation handling

  #### Removed
  - Removed `MockWallet` implementation in favor of `TestWallet`

  ### Related Issues
  - Closes #219
  - Addresses authentication issues from #217 and #220