### PR TITLE
feat(bdk): integrate validation and signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Every example below is self-contained and thoroughly commented. Browse the full 
 - [Validate SPV](./docs/examples/validate_spv/) — Validate SPV by decoding BEEF and checking merkle roots.
 - [Verify BEEF](./docs/examples/verify_beef/) — Verify a BEEF structure.
 - [Verify Transaction](./docs/examples/verify_transaction/) — Verify a transaction's scripts, merkle path, and fees.
+- [GoBDK Integration](./docs/examples/bdk/) — Opt into native transaction validation and secp256k1 signatures.
 
 ### Keys & Addresses
 - [Address From WIF](./docs/examples/address_from_wif/) — Derive an address from a WIF private key.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -23,6 +23,7 @@ Here, you will find a number of common usage examples for the go-sdk.
 - [Validate SPV](./validate_spv/) - Validate a Simple Payment Verification (SPV) proof.
 - [Verify BEEF](./verify_beef/) - Verify a BEEF (Background Evaluation Extended Format) transaction.
 - [Verify Transaction](./verify_transaction/) - Verify the validity of a Bitcoin transaction.
+- [GoBDK Integration](./bdk/) - Use native transaction validation and secp256k1 signatures.
 
 ## Messaging and Authentication
 - [Authenticated Messaging](./authenticated_messaging/) - Examples of authenticated messaging between parties.

--- a/docs/examples/bdk/README.md
+++ b/docs/examples/bdk/README.md
@@ -1,0 +1,43 @@
+# GoBDK integration
+
+The `transaction/bdk` package is an opt-in adapter between go-sdk and GoBDK's
+native transaction-validation and secp256k1 implementations.
+
+```bash
+go run ./docs/examples/bdk
+```
+
+The adapter is available with CGO on Linux and macOS for amd64 and arm64. It
+uses the native libraries distributed in
+`github.com/bitcoin-sv/bdk/module/gobdk`.
+
+## Transaction validation
+
+`NewValidator` supplies SDK-aware methods for full transaction validation,
+script validation, custom script flags, signature-operation counting, and
+batch validation. Transactions are converted to extended format, so every
+input must include its source output's locking script and satoshis. Validation
+also requires one UTXO height per input.
+
+Use `validator.Native()` to configure GoBDK policy settings that the adapter
+does not duplicate. Passing `consensus=false` to a validation method performs
+policy and consensus checks. Passing `consensus=true` performs consensus checks
+only.
+
+The SDK batch wrapper retains GoBDK's input buffers until `Clear` is called.
+Build and validate a batch on one goroutine, or provide external
+synchronization.
+
+## Signature backend
+
+`InstallSignatureBackend` selects GoBDK for the SDK's regular secp256k1 ECDSA
+signature creation and verification. It integrates at `PrivateKey.Sign` and
+`Signature.Verify`, so their callers—including wallet and message operations,
+transaction templates, `OP_CHECKSIG`, and `OP_CHECKMULTISIG`—use GoBDK as well.
+Compact signatures retain their SDK serialization and recovery logic while the
+underlying ECDSA signature is created by GoBDK.
+
+The signature backend accepts 32-byte message digests. Installation is explicit
+and process-wide, so configure it during application startup. Call
+`ResetSignatureBackend` to restore the pure-Go defaults. The separate generic
+P-256 package under `primitives/ecdsa` is unaffected.

--- a/docs/examples/bdk/main.go
+++ b/docs/examples/bdk/main.go
@@ -1,0 +1,68 @@
+//go:build cgo && (darwin || linux) && (amd64 || arm64)
+
+package main
+
+import (
+	"log"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/transaction/bdk"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
+)
+
+func main() {
+	privateKey, err := ec.PrivateKeyFromWif("cNGwGSc7KRrTmdLUZ54fiSXWbhLNDc2Eg5zNucgQxyQCzuQ5YRDq")
+	if err != nil {
+		log.Fatal(err)
+	}
+	address, err := script.NewAddressFromPublicKey(privateKey.PubKey(), true)
+	if err != nil {
+		log.Fatal(err)
+	}
+	lockingScript, err := p2pkh.Lock(address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	unlocker, err := p2pkh.Unlock(privateKey, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tx := transaction.NewTransaction()
+	if err = tx.AddInputFrom(
+		"45be95d2f2c64e99518ffbbce03fb15a7758f20ee5eecf0df07938d977add71d",
+		0,
+		lockingScript.String(),
+		1000,
+		unlocker,
+	); err != nil {
+		log.Fatal(err)
+	}
+	tx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      900,
+		LockingScript: lockingScript,
+	})
+
+	// Installation changes all SDK secp256k1 signing and verification calls.
+	bdk.InstallSignatureBackend()
+	defer bdk.ResetSignatureBackend()
+	if err = tx.Sign(); err != nil {
+		log.Fatal(err)
+	}
+
+	validator, err := bdk.NewValidator("main")
+	if err != nil {
+		log.Fatal(err)
+	}
+	validator.Native().SetRequireStandard(true)
+
+	// Each input needs the height of the UTXO it spends. consensus=false
+	// requests both policy and consensus validation.
+	if err = validator.ValidateTransaction(tx, []int32{899999}, 900000, false); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Print("BDK validation succeeded")
+}

--- a/docs/examples/bdk/main.go
+++ b/docs/examples/bdk/main.go
@@ -1,4 +1,4 @@
-//go:build cgo && (darwin || linux) && (amd64 || arm64)
+//go:build cgo && !ios && !android && (darwin || linux) && (amd64 || arm64)
 
 package main
 

--- a/docs/examples/bdk/main_unsupported.go
+++ b/docs/examples/bdk/main_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !cgo || ios || android || (!darwin && !linux) || (!amd64 && !arm64)
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("GoBDK requires CGO on a supported Linux or macOS amd64/arm64 target")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bsv-blockchain/go-sdk
 go 1.25.0
 
 require (
+	github.com/bitcoin-sv/bdk/module/gobdk v1.2.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bitcoin-sv/bdk/module/gobdk v1.2.4 h1:xuAJTgeCvgtiqRM+C8QWVVDquc/Ik2J6hNHJfwPUZQI=
+github.com/bitcoin-sv/bdk/module/gobdk v1.2.4/go.mod h1:6maRlx9FmnAD5vxzSrjOQRyZUV39nbVr/4Tx7hlPlAU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/primitives/ec/privatekey.go
+++ b/primitives/ec/privatekey.go
@@ -158,11 +158,25 @@ func (p *PrivateKey) PubKey() *PublicKey {
 	return (*PublicKey)(&p.PublicKey)
 }
 
-// Sign generates an ECDSA signature for the provided hash (which should be the result
-// of hashing a larger message) using the private key. Produced signature
-// is deterministic (same message and same key yield the same signature) and canonical
-// in accordance with RFC6979 and BIP0062.
+// Sign generates an ECDSA signature for the provided hash, which should be the
+// result of hashing a larger message. The built-in signer produces deterministic,
+// canonical signatures in accordance with RFC6979 and BIP0062. A signer installed
+// with InjectExternalSignerFn replaces the built-in implementation process-wide.
 func (p *PrivateKey) Sign(hash []byte) (*Signature, error) {
+	if signer := getExternalSignerFn(); signer != nil {
+		serializedSignature, err := signer(hash, p.Serialize())
+		if err != nil {
+			return nil, err
+		}
+		signature, err := ParseDERSignature(serializedSignature)
+		if err != nil {
+			return nil, fmt.Errorf("invalid signature from external signer: %w", err)
+		}
+		if !bytes.Equal(signature.Serialize(), serializedSignature) {
+			return nil, errors.New("external signer returned a non-canonical DER signature")
+		}
+		return signature, nil
+	}
 	return signRFC6979(p, hash)
 }
 

--- a/primitives/ec/signature.go
+++ b/primitives/ec/signature.go
@@ -97,12 +97,37 @@ func (sig *Signature) Serialize() []byte {
 // external verifier when one is installed and otherwise uses crypto/ecdsa.
 func (sig *Signature) Verify(hash []byte, pubKey *PublicKey) bool {
 	if verifier := getExternalVerifySignatureFn(); verifier != nil {
-		if !sig.hasValidScalars() {
+		if sig == nil || sig.R == nil || sig.S == nil ||
+			pubKey == nil || pubKey.Curve == nil || pubKey.X == nil || pubKey.Y == nil {
+			return false
+		}
+
+		// The external verifier accepts only secp256k1 public keys. Preserve
+		// crypto/ecdsa behavior for callers using another curve.
+		curve, ok := pubKey.Curve.(*KoblitzCurve)
+		if !ok || curve != S256() {
+			return e.Verify(pubKey.ToECDSA(), hash, sig.R, sig.S)
+		}
+
+		// Compressed serialization discards all but X and Y's parity. Without
+		// validating the point first, an off-curve key can serialize to the same
+		// bytes as a valid key and be accepted by the external verifier.
+		if !sig.hasValidScalars() || !validSecp256k1PublicKey(curve, pubKey) {
 			return false
 		}
 		return verifier(hash, sig.Serialize(), pubKey.Compressed())
 	}
 	return e.Verify(pubKey.ToECDSA(), hash, sig.R, sig.S)
+}
+
+func validSecp256k1PublicKey(curve *KoblitzCurve, pubKey *PublicKey) bool {
+	// KoblitzCurve.IsOnCurve converts coordinates to fixed-width field values.
+	// Check the affine coordinate range first so negative or oversized values
+	// cannot be truncated to a different valid point.
+	fieldPrime := curve.Params().P
+	return pubKey.X.Sign() >= 0 && pubKey.Y.Sign() >= 0 &&
+		pubKey.X.Cmp(fieldPrime) < 0 && pubKey.Y.Cmp(fieldPrime) < 0 &&
+		curve.IsOnCurve(pubKey.X, pubKey.Y)
 }
 
 func (sig *Signature) hasValidScalars() bool {

--- a/primitives/ec/signature.go
+++ b/primitives/ec/signature.go
@@ -32,7 +32,7 @@ func (sig *Signature) ToDER() ([]byte, error) {
 
 // Verify checks the validity of an ECDSA signature.
 func Verify(msg []byte, sig *Signature, pubKey *e.PublicKey) bool {
-	return e.Verify(pubKey, msg, sig.R, sig.S)
+	return sig.Verify(msg, (*PublicKey)(pubKey))
 }
 
 // FromDER decodes a DER encoded signature.
@@ -93,10 +93,22 @@ func (sig *Signature) Serialize() []byte {
 	return b
 }
 
-// Verify calls ecdsa.Verify to verify the signature of hash using the public
-// key.  It returns true if the signature is valid, false otherwise.
+// Verify verifies the signature of hash using the public key. It uses an
+// external verifier when one is installed and otherwise uses crypto/ecdsa.
 func (sig *Signature) Verify(hash []byte, pubKey *PublicKey) bool {
+	if verifier := getExternalVerifySignatureFn(); verifier != nil {
+		if !sig.hasValidScalars() {
+			return false
+		}
+		return verifier(hash, sig.Serialize(), pubKey.Compressed())
+	}
 	return e.Verify(pubKey.ToECDSA(), hash, sig.R, sig.S)
+}
+
+func (sig *Signature) hasValidScalars() bool {
+	return sig != nil && sig.R != nil && sig.S != nil &&
+		sig.R.Sign() == 1 && sig.S.Sign() == 1 &&
+		sig.R.Cmp(S256().N) < 0 && sig.S.Cmp(S256().N) < 0
 }
 
 // IsEqual compares this Signature instance to the one passed, returning true

--- a/primitives/ec/signature_backend.go
+++ b/primitives/ec/signature_backend.go
@@ -1,0 +1,52 @@
+package primitives
+
+import "sync"
+
+type externalSignatureBackend struct {
+	sync.RWMutex
+
+	signer   func(message, privateKey []byte) ([]byte, error)
+	verifier func(message, signature, publicKey []byte) bool
+}
+
+var signatureBackend externalSignatureBackend
+
+// InjectExternalSignerFn installs an external secp256k1 ECDSA signer. The
+// signer receives a message digest and a 32-byte private key and must return a
+// strict DER-encoded signature. Passing nil restores the built-in pure-Go
+// signer.
+//
+// The configured signer is process-wide and safe to call concurrently.
+// Applications should normally configure it during startup.
+func InjectExternalSignerFn(fn func(message, privateKey []byte) ([]byte, error)) {
+	signatureBackend.Lock()
+	signatureBackend.signer = fn
+	signatureBackend.Unlock()
+}
+
+// InjectExternalVerifySignatureFn installs an external secp256k1 ECDSA
+// verifier. The verifier receives a message digest, a strict DER-encoded
+// signature, and a compressed public key. Passing nil restores the built-in
+// pure-Go verifier.
+//
+// The configured verifier is process-wide and safe to call concurrently.
+// Applications should normally configure it during startup.
+func InjectExternalVerifySignatureFn(fn func(message, signature, publicKey []byte) bool) {
+	signatureBackend.Lock()
+	signatureBackend.verifier = fn
+	signatureBackend.Unlock()
+}
+
+func getExternalSignerFn() func(message, privateKey []byte) ([]byte, error) {
+	signatureBackend.RLock()
+	fn := signatureBackend.signer
+	signatureBackend.RUnlock()
+	return fn
+}
+
+func getExternalVerifySignatureFn() func(message, signature, publicKey []byte) bool {
+	signatureBackend.RLock()
+	fn := signatureBackend.verifier
+	signatureBackend.RUnlock()
+	return fn
+}

--- a/primitives/ec/signature_backend.go
+++ b/primitives/ec/signature_backend.go
@@ -13,8 +13,8 @@ var signatureBackend externalSignatureBackend
 
 // InjectExternalSignerFn installs an external secp256k1 ECDSA signer. The
 // signer receives a message digest and a 32-byte private key and must return a
-// strict DER-encoded signature. Passing nil restores the built-in pure-Go
-// signer.
+// canonical, low-S, strict DER-encoded signature. Passing nil restores the
+// built-in pure-Go signer.
 //
 // The configured signer is process-wide and safe to call concurrently.
 // Applications should normally configure it during startup.

--- a/primitives/ec/signature_backend_test.go
+++ b/primitives/ec/signature_backend_test.go
@@ -1,6 +1,9 @@
 package primitives
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"math/big"
@@ -98,6 +101,34 @@ func TestInjectExternalVerifySignatureFn(t *testing.T) {
 	}
 	require.False(t, invalidSignature.Verify(digest[:], privateKey.PubKey()))
 	require.Equal(t, 2, callCount)
+
+	validPublicKey := privateKey.PubKey()
+	invalidPublicKey := &PublicKey{
+		Curve: S256(),
+		X:     new(big.Int).Set(validPublicKey.X),
+		Y:     new(big.Int).Add(validPublicKey.Y, big.NewInt(2)),
+	}
+	require.False(t, invalidPublicKey.Validate())
+	require.Equal(t, validPublicKey.Compressed(), invalidPublicKey.Compressed())
+	require.False(t, signature.Verify(digest[:], invalidPublicKey))
+	require.Equal(t, 2, callCount, "external verifier must not receive an invalid public key")
+	negativePublicKey := &PublicKey{
+		Curve: S256(),
+		X:     new(big.Int).Set(validPublicKey.X),
+		Y:     new(big.Int).Neg(validPublicKey.Y),
+	}
+	require.Equal(t, validPublicKey.Compressed(), negativePublicKey.Compressed())
+	require.False(t, signature.Verify(digest[:], negativePublicKey))
+	require.Equal(t, 2, callCount, "external verifier must reject out-of-range coordinates")
+
+	p256PrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	p256Digest := sha256.Sum256([]byte("built-in verifier fallback"))
+	p256R, p256S, err := ecdsa.Sign(rand.Reader, p256PrivateKey, p256Digest[:])
+	require.NoError(t, err)
+	p256Signature := &Signature{R: p256R, S: p256S}
+	require.True(t, p256Signature.Verify(p256Digest[:], (*PublicKey)(&p256PrivateKey.PublicKey)))
+	require.Equal(t, 2, callCount, "external secp256k1 verifier must not receive another curve")
 
 	InjectExternalVerifySignatureFn(nil)
 	require.True(t, signature.Verify(digest[:], privateKey.PubKey()))

--- a/primitives/ec/signature_backend_test.go
+++ b/primitives/ec/signature_backend_test.go
@@ -1,0 +1,104 @@
+package primitives
+
+import (
+	"crypto/sha256"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectExternalSignerFn(t *testing.T) {
+	InjectExternalSignerFn(nil)
+	t.Cleanup(func() { InjectExternalSignerFn(nil) })
+
+	privateKey, err := PrivateKeyFromHex("1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd")
+	require.NoError(t, err)
+	digest := sha256.Sum256([]byte("external signer"))
+	wantSignature, err := privateKey.Sign(digest[:])
+	require.NoError(t, err)
+
+	t.Run("uses external signer", func(t *testing.T) {
+		called := false
+		InjectExternalSignerFn(func(message, privateKeyBytes []byte) ([]byte, error) {
+			called = true
+			require.Equal(t, digest[:], message)
+			require.Equal(t, privateKey.Serialize(), privateKeyBytes)
+			return wantSignature.Serialize(), nil
+		})
+
+		gotSignature, signErr := privateKey.Sign(digest[:])
+		require.NoError(t, signErr)
+		require.True(t, wantSignature.IsEqual(gotSignature))
+		require.True(t, called)
+	})
+
+	t.Run("returns external error", func(t *testing.T) {
+		wantErr := errors.New("external signer failure")
+		InjectExternalSignerFn(func(_, _ []byte) ([]byte, error) {
+			return nil, wantErr
+		})
+
+		_, signErr := privateKey.Sign(digest[:])
+		require.ErrorIs(t, signErr, wantErr)
+	})
+
+	t.Run("rejects malformed signature", func(t *testing.T) {
+		InjectExternalSignerFn(func(_, _ []byte) ([]byte, error) {
+			return []byte{0x01, 0x02}, nil
+		})
+
+		_, signErr := privateKey.Sign(digest[:])
+		require.Error(t, signErr)
+	})
+
+	t.Run("nil restores built-in signer", func(t *testing.T) {
+		InjectExternalSignerFn(nil)
+		gotSignature, signErr := privateKey.Sign(digest[:])
+		require.NoError(t, signErr)
+		require.True(t, wantSignature.IsEqual(gotSignature))
+	})
+}
+
+func TestInjectExternalVerifySignatureFn(t *testing.T) {
+	InjectExternalSignerFn(nil)
+	InjectExternalVerifySignatureFn(nil)
+	t.Cleanup(func() {
+		InjectExternalSignerFn(nil)
+		InjectExternalVerifySignatureFn(nil)
+	})
+
+	privateKey, err := PrivateKeyFromHex("1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd")
+	require.NoError(t, err)
+	digest := sha256.Sum256([]byte("external verifier"))
+	signature, err := privateKey.Sign(digest[:])
+	require.NoError(t, err)
+
+	callCount := 0
+	InjectExternalVerifySignatureFn(func(message, signatureBytes, publicKey []byte) bool {
+		callCount++
+		require.Equal(t, digest[:], message)
+		require.Equal(t, signature.Serialize(), signatureBytes)
+		require.Equal(t, privateKey.PubKey().Compressed(), publicKey)
+		return false
+	})
+
+	require.False(t, signature.Verify(digest[:], privateKey.PubKey()))
+	require.False(t, Verify(digest[:], signature, privateKey.PubKey().ToECDSA()))
+	require.Equal(t, 2, callCount)
+
+	InjectExternalVerifySignatureFn(func(_, _, _ []byte) bool {
+		callCount++
+		return true
+	})
+	invalidSignature := &Signature{
+		R: new(big.Int).Neg(signature.R),
+		S: new(big.Int).Set(signature.S),
+	}
+	require.False(t, invalidSignature.Verify(digest[:], privateKey.PubKey()))
+	require.Equal(t, 2, callCount)
+
+	InjectExternalVerifySignatureFn(nil)
+	require.True(t, signature.Verify(digest[:], privateKey.PubKey()))
+}

--- a/script/interpreter/operations.go
+++ b/script/interpreter/operations.go
@@ -25,12 +25,6 @@ const (
 	opCondSkip  = 2
 )
 
-var externalVerifySignatureFn func(payload, signature, publicKey []byte) bool = nil
-
-func InjectExternalVerifySignatureFn(fn func(payload, signature, publicKey []byte) bool) {
-	externalVerifySignatureFn = fn
-}
-
 type opcode struct {
 	val    byte
 	name   string
@@ -2019,7 +2013,7 @@ func opcodeCheckSig(op *ParsedOpcode, t *thread) error {
 
 	var sigBytesDer []byte
 	// if the signature is in DER format, we can set it here and just use it
-	// directly if an externalVerifySignatureFn is set
+	// directly if an external verifier is set
 	if t.hasAny(scriptflag.VerifyStrictEncoding, scriptflag.VerifyDERSignatures) {
 		sigBytesDer = sigBytes
 	}
@@ -2027,7 +2021,7 @@ func opcodeCheckSig(op *ParsedOpcode, t *thread) error {
 	var ok bool
 	var signature *ec.Signature
 
-	if externalVerifySignatureFn != nil {
+	if verifySignature := getExternalVerifySignatureFn(); verifySignature != nil {
 		if sigBytesDer == nil {
 			// signature is not in DER format, so we must parse it and set the bytes
 			signature, err = ec.ParseSignature(sigBytes)
@@ -2039,7 +2033,7 @@ func opcodeCheckSig(op *ParsedOpcode, t *thread) error {
 				return err
 			}
 		}
-		ok = externalVerifySignatureFn(hash, sigBytesDer, pkBytes)
+		ok = verifySignature(hash, sigBytesDer, pkBytes)
 	} else {
 		var pubKey *ec.PublicKey
 		pubKey, err = ec.ParsePubKey(pkBytes)

--- a/script/interpreter/signature_verifier.go
+++ b/script/interpreter/signature_verifier.go
@@ -1,0 +1,28 @@
+package interpreter
+
+import "sync"
+
+var externalSignatureVerifier = struct {
+	sync.RWMutex
+
+	fn func(payload, signature, publicKey []byte) bool
+}{}
+
+// InjectExternalVerifySignatureFn installs an external signature verifier for
+// OP_CHECKSIG and OP_CHECKSIGVERIFY. Passing nil restores the built-in
+// verifier.
+//
+// The configured verifier is process-wide and safe to call concurrently.
+// Applications should normally configure it during startup.
+func InjectExternalVerifySignatureFn(fn func(payload, signature, publicKey []byte) bool) {
+	externalSignatureVerifier.Lock()
+	externalSignatureVerifier.fn = fn
+	externalSignatureVerifier.Unlock()
+}
+
+func getExternalVerifySignatureFn() func(payload, signature, publicKey []byte) bool {
+	externalSignatureVerifier.RLock()
+	fn := externalSignatureVerifier.fn
+	externalSignatureVerifier.RUnlock()
+	return fn
+}

--- a/script/interpreter/signature_verifier_test.go
+++ b/script/interpreter/signature_verifier_test.go
@@ -1,0 +1,51 @@
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectExternalVerifySignatureFn(t *testing.T) {
+	t.Cleanup(func() { interpreter.InjectExternalVerifySignatureFn(nil) })
+
+	const signedTx = "010000000193a35408b6068499e0d5abd799d3e827d9bfe70c9b75ebe209c91d2507232651000000006b483045022100c1d77036dc6cd1f3fa1214b0688391ab7f7a16cd31ea4e5a1f7a415ef167df820220751aced6d24649fa235132f1e6969e163b9400f80043a72879237dab4a1190ad412103b8b40a84123121d260f5c109bc5a46ec819c2e4002e5ba08638783bfb4e01435ffffffff02404b4c00000000001976a91404ff367be719efa79d76e4416ffb072cd53b208888acde94a905000000001976a91404d03f746652cfcb6cb55119ab473a045137d26588ac00000000"
+	tx, err := transaction.NewTransactionFromHex(signedTx)
+	require.NoError(t, err)
+
+	lockingScript, err := script.NewFromHex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+	require.NoError(t, err)
+	previousOutput := &transaction.TransactionOutput{
+		Satoshis:      100000000,
+		LockingScript: lockingScript,
+	}
+	tx.Inputs[0].SetSourceTxOutput(previousOutput)
+
+	callCount := 0
+	interpreter.InjectExternalVerifySignatureFn(func(payload, signature, publicKey []byte) bool {
+		callCount++
+		require.Len(t, payload, 32)
+		require.NotEmpty(t, signature)
+		require.Contains(t, []int{33, 65}, len(publicKey))
+		return true
+	})
+
+	err = interpreter.NewEngine().Execute(
+		interpreter.WithTx(tx, 0, previousOutput),
+		interpreter.WithForkID(),
+		interpreter.WithAfterGenesis(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount)
+
+	interpreter.InjectExternalVerifySignatureFn(nil)
+	err = interpreter.NewEngine().Execute(
+		interpreter.WithTx(tx, 0, previousOutput),
+		interpreter.WithForkID(),
+		interpreter.WithAfterGenesis(),
+	)
+	require.NoError(t, err)
+}

--- a/transaction/bdk/bdk.go
+++ b/transaction/bdk/bdk.go
@@ -1,0 +1,261 @@
+//go:build cgo && (darwin || linux) && (amd64 || arm64)
+
+// Package bdk adapts go-sdk transactions and secp256k1 signatures to GoBDK's
+// native implementations.
+//
+// GoBDK ships prebuilt native libraries. This package is available only with
+// CGO on supported Linux and macOS amd64/arm64 targets. Importing the package
+// does not change SDK behavior; callers must explicitly install the signature
+// backend or construct a Validator.
+package bdk
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"runtime"
+
+	bdkscript "github.com/bitcoin-sv/bdk/module/gobdk/script"
+	bdksecp256k1 "github.com/bitcoin-sv/bdk/module/gobdk/secp256k1"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+var (
+	// ErrNilTransaction is returned when an operation receives a nil transaction.
+	ErrNilTransaction = errors.New("bdk: transaction is nil")
+	// ErrNilValidator is returned when an operation receives a nil validator.
+	ErrNilValidator = errors.New("bdk: validator is nil")
+	// ErrNilBatch is returned when an operation receives a nil validation batch.
+	ErrNilBatch = errors.New("bdk: validation batch is nil")
+	// ErrUnsupportedNetwork is returned when GoBDK does not recognize a network name.
+	ErrUnsupportedNetwork = errors.New("bdk: unsupported network")
+	// ErrUTXOHeightCount is returned when there is not one UTXO height per input.
+	ErrUTXOHeightCount = errors.New("bdk: UTXO height count does not match input count")
+	// ErrCustomFlagCount is returned when custom flags are neither empty nor one per input.
+	ErrCustomFlagCount = errors.New("bdk: custom flag count does not match input count")
+)
+
+// Validator adapts transaction.Transaction values to a GoBDK TxValidator.
+type Validator struct {
+	native *bdkscript.TxValidator
+}
+
+// NewValidator creates a GoBDK transaction validator for network. GoBDK
+// recognizes main, test, regtest, stn, teratestnet, and tstn.
+func NewValidator(network string) (*Validator, error) {
+	native := bdkscript.NewTxValidator(network)
+	if native == nil {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedNetwork, network)
+	}
+	return &Validator{native: native}, nil
+}
+
+// WrapValidator adapts an existing, potentially policy-configured GoBDK
+// validator.
+func WrapValidator(native *bdkscript.TxValidator) (*Validator, error) {
+	if native == nil {
+		return nil, ErrNilValidator
+	}
+	return &Validator{native: native}, nil
+}
+
+// Native returns the underlying GoBDK validator. It can be used to configure
+// GoBDK policy settings not duplicated by this adapter.
+func (v *Validator) Native() *bdkscript.TxValidator {
+	if v == nil {
+		return nil
+	}
+	return v.native
+}
+
+// ValidateTransaction runs GoBDK's transaction-level and script validation.
+// Setting consensus to false applies policy and consensus checks; true applies
+// consensus checks only.
+func (v *Validator) ValidateTransaction(tx *transaction.Transaction, utxoHeights []int32, blockHeight int32, consensus bool) error {
+	if err := v.valid(); err != nil {
+		return err
+	}
+	extendedTx, err := validationArguments(tx, utxoHeights, nil)
+	if err != nil {
+		return err
+	}
+	return v.native.ValidateTransaction(extendedTx, utxoHeights, blockHeight, consensus)
+}
+
+// VerifyScript verifies every input script with flags calculated by GoBDK.
+func (v *Validator) VerifyScript(tx *transaction.Transaction, utxoHeights []int32, blockHeight int32, consensus bool) error {
+	if err := v.valid(); err != nil {
+		return err
+	}
+	extendedTx, err := validationArguments(tx, utxoHeights, nil)
+	if err != nil {
+		return err
+	}
+	return v.native.VerifyScript(extendedTx, utxoHeights, blockHeight, consensus)
+}
+
+// VerifyScriptWithCustomFlags verifies every input script using customFlags.
+// customFlags may be empty or must contain one entry per transaction input.
+func (v *Validator) VerifyScriptWithCustomFlags(tx *transaction.Transaction, utxoHeights []int32, blockHeight int32, consensus bool, customFlags []uint32) error {
+	if err := v.valid(); err != nil {
+		return err
+	}
+	extendedTx, err := validationArguments(tx, utxoHeights, customFlags)
+	if err != nil {
+		return err
+	}
+	return v.native.VerifyScriptWithCustomFlags(extendedTx, utxoHeights, blockHeight, consensus, customFlags)
+}
+
+// GetSigOpCount returns GoBDK's signature-operation count for tx.
+func (v *Validator) GetSigOpCount(tx *transaction.Transaction, utxoHeights []int32, blockHeight int32, countP2SHSigOps bool, consensus bool) (uint64, error) {
+	if err := v.valid(); err != nil {
+		return 0, err
+	}
+	extendedTx, err := validationArguments(tx, utxoHeights, nil)
+	if err != nil {
+		return 0, err
+	}
+	return v.native.GetSigOpCount(extendedTx, utxoHeights, blockHeight, countP2SHSigOps, consensus)
+}
+
+func (v *Validator) valid() error {
+	if v == nil || v.native == nil {
+		return ErrNilValidator
+	}
+	return nil
+}
+
+func validationArguments(tx *transaction.Transaction, utxoHeights []int32, customFlags []uint32) ([]byte, error) {
+	if tx == nil {
+		return nil, ErrNilTransaction
+	}
+	inputCount := len(tx.Inputs)
+	if len(utxoHeights) != inputCount {
+		return nil, fmt.Errorf("%w: got %d heights for %d inputs", ErrUTXOHeightCount, len(utxoHeights), inputCount)
+	}
+	if len(customFlags) != 0 && len(customFlags) != inputCount {
+		return nil, fmt.Errorf("%w: got %d flags for %d inputs", ErrCustomFlagCount, len(customFlags), inputCount)
+	}
+	extendedTx, err := tx.EF()
+	if err != nil {
+		return nil, err
+	}
+	return extendedTx, nil
+}
+
+// ValidateBatch adapts a GoBDK validation batch to go-sdk transactions.
+//
+// A batch is not safe for concurrent use. All Add calls and the corresponding
+// Validator.ValidateBatch call must run on the same goroutine unless the caller
+// provides external synchronization.
+type ValidateBatch struct {
+	native          *bdkscript.ValidateBatch
+	extendedTxs     [][]byte
+	utxoHeightLists [][]int32
+}
+
+// NewValidateBatch creates a validation batch. An optional positive capacity
+// preallocates the underlying GoBDK batch.
+func NewValidateBatch(capacity ...int) *ValidateBatch {
+	native := bdkscript.NewValidateBatch(capacity...)
+	if native == nil {
+		return nil
+	}
+	return &ValidateBatch{native: native}
+}
+
+// Add serializes and adds tx to the batch. The adapter retains the serialized
+// transaction and a private copy of the heights until Clear is called because
+// GoBDK retains their memory while processing the batch.
+func (b *ValidateBatch) Add(tx *transaction.Transaction, utxoHeights []int32, blockHeight int32, consensus bool) error {
+	if b == nil || b.native == nil {
+		return ErrNilBatch
+	}
+	extendedTx, err := validationArguments(tx, utxoHeights, nil)
+	if err != nil {
+		return err
+	}
+	heights := append([]int32(nil), utxoHeights...)
+	b.extendedTxs = append(b.extendedTxs, extendedTx)
+	b.utxoHeightLists = append(b.utxoHeightLists, heights)
+	b.native.Add(extendedTx, heights, blockHeight, consensus)
+	runtime.KeepAlive(b.extendedTxs)
+	runtime.KeepAlive(b.utxoHeightLists)
+	return nil
+}
+
+// ValidateBatch validates every entry and returns one error per entry in
+// insertion order. A nil entry represents successful validation.
+func (v *Validator) ValidateBatch(batch *ValidateBatch) ([]error, error) {
+	if err := v.valid(); err != nil {
+		return nil, err
+	}
+	if batch == nil || batch.native == nil {
+		return nil, ErrNilBatch
+	}
+	results := v.native.ValidateBatch(batch.native)
+	runtime.KeepAlive(batch.extendedTxs)
+	runtime.KeepAlive(batch.utxoHeightLists)
+	return results, nil
+}
+
+// Clear removes all entries and releases the Go buffers retained by the batch.
+func (b *ValidateBatch) Clear() {
+	if b == nil || b.native == nil {
+		return
+	}
+	b.native.Clear()
+	b.extendedTxs = nil
+	b.utxoHeightLists = nil
+}
+
+// Size returns the number of entries in the batch.
+func (b *ValidateBatch) Size() int {
+	if b == nil || b.native == nil {
+		return 0
+	}
+	return b.native.Size()
+}
+
+// Empty reports whether the batch contains no entries.
+func (b *ValidateBatch) Empty() bool {
+	return b == nil || b.native == nil || b.native.Empty()
+}
+
+// Reserve preallocates space for capacity entries.
+func (b *ValidateBatch) Reserve(capacity int) {
+	if b == nil || b.native == nil {
+		return
+	}
+	b.native.Reserve(capacity)
+}
+
+// InstallSignatureBackend selects GoBDK's secp256k1 implementation for SDK
+// ECDSA signature creation and verification. This includes direct EC calls,
+// wallet and message signatures, transaction templates, OP_CHECKSIG, and
+// OP_CHECKMULTISIG. The selection is process-wide and should normally be made
+// during application startup.
+func InstallSignatureBackend() {
+	ec.InjectExternalSignerFn(bdksecp256k1.SignMessage)
+	ec.InjectExternalVerifySignatureFn(verifySignature)
+	interpreter.InjectExternalVerifySignatureFn(verifySignature)
+}
+
+// ResetSignatureBackend restores the SDK's built-in pure-Go signature creation
+// and verification implementation.
+func ResetSignatureBackend() {
+	ec.InjectExternalSignerFn(nil)
+	ec.InjectExternalVerifySignatureFn(nil)
+	interpreter.InjectExternalVerifySignatureFn(nil)
+}
+
+func verifySignature(message, signature, publicKey []byte) bool {
+	// GoBDK's C API reads a 32-byte digest without checking the Go slice length.
+	if len(message) != sha256.Size {
+		return false
+	}
+	return bdksecp256k1.VerifySignature(message, signature, publicKey)
+}

--- a/transaction/bdk/bdk.go
+++ b/transaction/bdk/bdk.go
@@ -1,4 +1,4 @@
-//go:build cgo && (darwin || linux) && (amd64 || arm64)
+//go:build cgo && !ios && !android && (darwin || linux) && (amd64 || arm64)
 
 // Package bdk adapts go-sdk transactions and secp256k1 signatures to GoBDK's
 // native implementations.
@@ -155,6 +155,7 @@ type ValidateBatch struct {
 	native          *bdkscript.ValidateBatch
 	extendedTxs     [][]byte
 	utxoHeightLists [][]int32
+	pinner          *runtime.Pinner
 }
 
 // NewValidateBatch creates a validation batch. An optional positive capacity
@@ -164,12 +165,22 @@ func NewValidateBatch(capacity ...int) *ValidateBatch {
 	if native == nil {
 		return nil
 	}
-	return &ValidateBatch{native: native}
+	batch := &ValidateBatch{
+		native: native,
+		pinner: new(runtime.Pinner),
+	}
+	runtime.SetFinalizer(batch, finalizeValidateBatch)
+	return batch
 }
 
-// Add serializes and adds tx to the batch. The adapter retains the serialized
-// transaction and a private copy of the heights until Clear is called because
-// GoBDK retains their memory while processing the batch.
+func finalizeValidateBatch(batch *ValidateBatch) {
+	batch.Clear()
+}
+
+// Add serializes and adds tx to the batch. The adapter pins and retains the
+// serialized transaction and a private copy of the heights until Clear is
+// called because GoBDK retains pointers to their memory while processing the
+// batch.
 func (b *ValidateBatch) Add(tx *transaction.Transaction, utxoHeights []int32, blockHeight int32, consensus bool) error {
 	if b == nil || b.native == nil {
 		return ErrNilBatch
@@ -179,11 +190,16 @@ func (b *ValidateBatch) Add(tx *transaction.Transaction, utxoHeights []int32, bl
 		return err
 	}
 	heights := append([]int32(nil), utxoHeights...)
+	if len(extendedTx) > 0 {
+		b.pinner.Pin(&extendedTx[0])
+	}
+	if len(heights) > 0 {
+		b.pinner.Pin(&heights[0])
+	}
 	b.extendedTxs = append(b.extendedTxs, extendedTx)
 	b.utxoHeightLists = append(b.utxoHeightLists, heights)
 	b.native.Add(extendedTx, heights, blockHeight, consensus)
-	runtime.KeepAlive(b.extendedTxs)
-	runtime.KeepAlive(b.utxoHeightLists)
+	runtime.KeepAlive(b)
 	return nil
 }
 
@@ -197,17 +213,19 @@ func (v *Validator) ValidateBatch(batch *ValidateBatch) ([]error, error) {
 		return nil, ErrNilBatch
 	}
 	results := v.native.ValidateBatch(batch.native)
-	runtime.KeepAlive(batch.extendedTxs)
-	runtime.KeepAlive(batch.utxoHeightLists)
+	runtime.KeepAlive(batch)
 	return results, nil
 }
 
-// Clear removes all entries and releases the Go buffers retained by the batch.
+// Clear removes all entries, unpins their Go buffers, and releases them.
 func (b *ValidateBatch) Clear() {
 	if b == nil || b.native == nil {
 		return
 	}
+	// GoBDK stores spans into the pinned buffers. Clear the native spans before
+	// making the Go memory movable and collectible again.
 	b.native.Clear()
+	b.pinner.Unpin()
 	b.extendedTxs = nil
 	b.utxoHeightLists = nil
 }

--- a/transaction/bdk/bdk.go
+++ b/transaction/bdk/bdk.go
@@ -1,12 +1,5 @@
 //go:build cgo && !ios && !android && (darwin || linux) && (amd64 || arm64)
 
-// Package bdk adapts go-sdk transactions and secp256k1 signatures to GoBDK's
-// native implementations.
-//
-// GoBDK ships prebuilt native libraries. This package is available only with
-// CGO on supported Linux and macOS amd64/arm64 targets. Importing the package
-// does not change SDK behavior; callers must explicitly install the signature
-// backend or construct a Validator.
 package bdk
 
 import (
@@ -257,7 +250,7 @@ func (b *ValidateBatch) Reserve(capacity int) {
 // OP_CHECKMULTISIG. The selection is process-wide and should normally be made
 // during application startup.
 func InstallSignatureBackend() {
-	ec.InjectExternalSignerFn(bdksecp256k1.SignMessage)
+	ec.InjectExternalSignerFn(signMessage)
 	ec.InjectExternalVerifySignatureFn(verifySignature)
 	interpreter.InjectExternalVerifySignatureFn(verifySignature)
 }
@@ -268,6 +261,15 @@ func ResetSignatureBackend() {
 	ec.InjectExternalSignerFn(nil)
 	ec.InjectExternalVerifySignatureFn(nil)
 	interpreter.InjectExternalVerifySignatureFn(nil)
+}
+
+func signMessage(message, privateKey []byte) ([]byte, error) {
+	// Keep the safety check at this adapter boundary instead of relying on the
+	// native dependency to reject a slice that is too short for a 32-byte read.
+	if len(message) != sha256.Size {
+		return nil, fmt.Errorf("bdk: message digest must be %d bytes: got %d", sha256.Size, len(message))
+	}
+	return bdksecp256k1.SignMessage(message, privateKey)
 }
 
 func verifySignature(message, signature, publicKey []byte) bool {

--- a/transaction/bdk/bdk_test.go
+++ b/transaction/bdk/bdk_test.go
@@ -161,7 +161,7 @@ func TestInstallSignatureBackend(t *testing.T) {
 	require.False(t, signature.Verify(invalidDigest[:], privateKey.PubKey()))
 	require.False(t, signature.Verify([]byte("short digest"), privateKey.PubKey()))
 	_, err = privateKey.Sign([]byte("short digest"))
-	require.Error(t, err)
+	require.EqualError(t, err, "bdk: message digest must be 32 bytes: got 12")
 
 	signedMessage, err := message.Sign([]byte("signed through GoBDK"), privateKey, nil)
 	require.NoError(t, err)

--- a/transaction/bdk/bdk_test.go
+++ b/transaction/bdk/bdk_test.go
@@ -1,0 +1,221 @@
+//go:build cgo && (darwin || linux) && (amd64 || arm64)
+
+package bdk_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"runtime"
+	"testing"
+
+	bdkscript "github.com/bitcoin-sv/bdk/module/gobdk/script"
+	bsm "github.com/bsv-blockchain/go-sdk/compat/bsm"
+	"github.com/bsv-blockchain/go-sdk/message"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/transaction/bdk"
+	sighash "github.com/bsv-blockchain/go-sdk/transaction/sighash"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBlockHeight = int32(620940)
+	testUTXOHeight  = int32(574441)
+	testExtendedTx  = "010000000000000000ef0120fa0d2c5974cfe6e3aec71f7f6539cfa1c1e474082d2cdb41fb830f6267b7d7000000006b4830450221008788b545ebd6ebcb15f938045b71c1fa7efafd55d1f4e64e96602a04f3214cda0220717ddadfa7d1dc6a22ccb077350aef7a2073ee58fe780d86b77a31c24c664a21412103ef28c47337b05ec3f14b63d904db7ae023e897389dbdbf531221e13fd5e5b105ffffffffdc3de103000000001976a91437fb14a40d021abbb1763497f963a130286d1ad188ac017239e103000000001976a914962eba38504bcfb140ff0246afa795658812b42788ac00000000"
+)
+
+func TestValidator(t *testing.T) {
+	validator, err := bdk.NewValidator("main")
+	require.NoError(t, err)
+	require.NotNil(t, validator.Native())
+
+	tx := mustTestTransaction(t)
+	extendedTx, err := tx.EF()
+	require.NoError(t, err)
+	wantExtendedTx, err := hex.DecodeString(testExtendedTx)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(wantExtendedTx, extendedTx))
+
+	utxoHeights := []int32{testUTXOHeight}
+	require.NoError(t, validator.ValidateTransaction(tx, utxoHeights, testBlockHeight, true))
+	require.NoError(t, validator.VerifyScript(tx, utxoHeights, testBlockHeight, true))
+
+	flags := []uint32{validator.Native().CalculateFlags(testUTXOHeight, testBlockHeight, true)}
+	require.NoError(t, validator.VerifyScriptWithCustomFlags(tx, utxoHeights, testBlockHeight, true, flags))
+
+	sigOps, err := validator.GetSigOpCount(tx, utxoHeights, testBlockHeight, true, true)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), sigOps)
+}
+
+func TestValidatorInputErrors(t *testing.T) {
+	_, err := bdk.NewValidator("not-a-network")
+	require.ErrorIs(t, err, bdk.ErrUnsupportedNetwork)
+
+	_, err = bdk.WrapValidator(nil)
+	require.ErrorIs(t, err, bdk.ErrNilValidator)
+
+	tx := mustTestTransaction(t)
+	utxoHeights := []int32{testUTXOHeight}
+	validator, err := bdk.NewValidator("main")
+	require.NoError(t, err)
+
+	require.ErrorIs(t, validator.ValidateTransaction(nil, nil, testBlockHeight, true), bdk.ErrNilTransaction)
+	require.ErrorIs(t, validator.ValidateTransaction(tx, nil, testBlockHeight, true), bdk.ErrUTXOHeightCount)
+	require.ErrorIs(
+		t,
+		validator.VerifyScriptWithCustomFlags(tx, utxoHeights, testBlockHeight, true, []uint32{1, 2}),
+		bdk.ErrCustomFlagCount,
+	)
+
+	withoutSourceOutput, err := transaction.NewTransactionFromHex(tx.Hex())
+	require.NoError(t, err)
+	require.ErrorIs(
+		t,
+		validator.ValidateTransaction(withoutSourceOutput, utxoHeights, testBlockHeight, true),
+		transaction.ErrEmptyPreviousTx,
+	)
+
+	var nilValidator *bdk.Validator
+	require.ErrorIs(t, nilValidator.ValidateTransaction(tx, utxoHeights, testBlockHeight, true), bdk.ErrNilValidator)
+	_, err = validator.ValidateBatch(nil)
+	require.ErrorIs(t, err, bdk.ErrNilBatch)
+}
+
+func TestValidateBatch(t *testing.T) {
+	validator, err := bdk.NewValidator("main")
+	require.NoError(t, err)
+
+	batch := bdk.NewValidateBatch(2)
+	require.NotNil(t, batch)
+	require.True(t, batch.Empty())
+	batch.Reserve(3)
+
+	heights := []int32{testUTXOHeight}
+	require.NoError(t, batch.Add(mustTestTransaction(t), heights, testBlockHeight, true))
+	heights[0] = 0
+
+	invalidTx := mustTestTransaction(t)
+	invalidUnlockingScript := script.NewFromBytes(*invalidTx.Inputs[0].UnlockingScript)
+	(*invalidUnlockingScript)[10] ^= 0x01
+	invalidTx.Inputs[0].UnlockingScript = invalidUnlockingScript
+	require.NoError(t, batch.Add(invalidTx, []int32{testUTXOHeight}, testBlockHeight, true))
+	require.Equal(t, 2, batch.Size())
+	require.False(t, batch.Empty())
+
+	runtime.GC()
+	results, err := validator.ValidateBatch(batch)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.NoError(t, results[0])
+	require.Error(t, results[1])
+	var scriptErr bdkscript.ScriptError
+	require.ErrorAs(t, results[1], &scriptErr)
+
+	batch.Clear()
+	require.Zero(t, batch.Size())
+	require.True(t, batch.Empty())
+}
+
+func TestInstallSignatureBackend(t *testing.T) {
+	bdk.ResetSignatureBackend()
+	t.Cleanup(bdk.ResetSignatureBackend)
+
+	privateKey, err := ec.PrivateKeyFromWif("cNGwGSc7KRrTmdLUZ54fiSXWbhLNDc2Eg5zNucgQxyQCzuQ5YRDq")
+	require.NoError(t, err)
+
+	bdk.InstallSignatureBackend()
+	digest := sha256.Sum256([]byte("GoBDK signature backend"))
+	signature, err := privateKey.Sign(digest[:])
+	require.NoError(t, err)
+	require.True(t, signature.Verify(digest[:], privateKey.PubKey()))
+	require.True(t, ec.Verify(digest[:], signature, privateKey.PubKey().ToECDSA()))
+
+	invalidDigest := digest
+	invalidDigest[0] ^= 0x01
+	require.False(t, signature.Verify(invalidDigest[:], privateKey.PubKey()))
+	require.False(t, signature.Verify([]byte("short digest"), privateKey.PubKey()))
+	_, err = privateKey.Sign([]byte("short digest"))
+	require.Error(t, err)
+
+	signedMessage, err := message.Sign([]byte("signed through GoBDK"), privateKey, nil)
+	require.NoError(t, err)
+	valid, err := message.Verify([]byte("signed through GoBDK"), signedMessage, nil)
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	address, err := script.NewAddressFromPublicKey(privateKey.PubKey(), true)
+	require.NoError(t, err)
+	compactMessage := []byte("compact signature through GoBDK")
+	compactSignature, err := bsm.SignMessage(privateKey, compactMessage)
+	require.NoError(t, err)
+	require.NoError(t, bsm.VerifyMessage(address.AddressString, compactSignature, compactMessage))
+
+	lockingScript, err := p2pkh.Lock(address)
+	require.NoError(t, err)
+	unlocker, err := p2pkh.Unlock(privateKey, nil)
+	require.NoError(t, err)
+
+	tx := transaction.NewTransaction()
+	require.NoError(t, tx.AddInputFrom(
+		"45be95d2f2c64e99518ffbbce03fb15a7758f20ee5eecf0df07938d977add71d",
+		0,
+		lockingScript.String(),
+		1000,
+		unlocker,
+	))
+	tx.AddOutput(&transaction.TransactionOutput{Satoshis: 900, LockingScript: lockingScript})
+	require.NoError(t, tx.Sign())
+
+	parts, err := script.DecodeScript(*tx.Inputs[0].UnlockingScript)
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	signatureWithHashType := parts[0].Data
+	require.NotEmpty(t, signatureWithHashType)
+	signature, err = ec.ParseDERSignature(signatureWithHashType[:len(signatureWithHashType)-1])
+	require.NoError(t, err)
+	digestBytes, err := tx.CalcInputSignatureHash(0, sighash.Flag(signatureWithHashType[len(signatureWithHashType)-1]))
+	require.NoError(t, err)
+	require.True(t, signature.Verify(digestBytes, privateKey.PubKey()))
+
+	previousOutput := tx.Inputs[0].SourceTxOutput()
+	require.NoError(t, interpreter.NewEngine().Execute(
+		interpreter.WithTx(tx, 0, previousOutput),
+		interpreter.WithForkID(),
+		interpreter.WithAfterGenesis(),
+	))
+
+	validator, err := bdk.NewValidator("main")
+	require.NoError(t, err)
+	require.NoError(t, validator.ValidateTransaction(tx, []int32{899999}, 900000, true))
+	require.NoError(t, validator.ValidateTransaction(tx, []int32{899999}, 900000, false))
+}
+
+func TestValidateBatchNilReceiver(t *testing.T) {
+	var batch *bdk.ValidateBatch
+	require.ErrorIs(t, batch.Add(mustTestTransaction(t), []int32{testUTXOHeight}, testBlockHeight, true), bdk.ErrNilBatch)
+	require.Zero(t, batch.Size())
+	require.True(t, batch.Empty())
+	batch.Reserve(1)
+	batch.Clear()
+}
+
+func ExampleValidator_ValidateTransaction() {
+	tx, _ := transaction.NewTransactionFromHex(testExtendedTx)
+	validator, _ := bdk.NewValidator("main")
+	err := validator.ValidateTransaction(tx, []int32{testUTXOHeight}, testBlockHeight, true)
+	fmt.Println(err == nil)
+	// Output: true
+}
+
+func mustTestTransaction(t *testing.T) *transaction.Transaction {
+	t.Helper()
+	tx, err := transaction.NewTransactionFromHex(testExtendedTx)
+	require.NoError(t, err)
+	return tx
+}

--- a/transaction/bdk/bdk_test.go
+++ b/transaction/bdk/bdk_test.go
@@ -1,4 +1,4 @@
-//go:build cgo && (darwin || linux) && (amd64 || arm64)
+//go:build cgo && !ios && !android && (darwin || linux) && (amd64 || arm64)
 
 package bdk_test
 
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"runtime"
 	"testing"
 
@@ -120,6 +121,15 @@ func TestValidateBatch(t *testing.T) {
 	batch.Clear()
 	require.Zero(t, batch.Size())
 	require.True(t, batch.Empty())
+
+	// Clearing releases the first set of pins without preventing batch reuse.
+	require.NoError(t, batch.Add(mustTestTransaction(t), []int32{testUTXOHeight}, testBlockHeight, true))
+	runtime.GC()
+	results, err = validator.ValidateBatch(batch)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0])
+	batch.Clear()
 }
 
 func TestInstallSignatureBackend(t *testing.T) {
@@ -135,6 +145,16 @@ func TestInstallSignatureBackend(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, signature.Verify(digest[:], privateKey.PubKey()))
 	require.True(t, ec.Verify(digest[:], signature, privateKey.PubKey().ToECDSA()))
+
+	validPublicKey := privateKey.PubKey()
+	invalidPublicKey := &ec.PublicKey{
+		Curve: ec.S256(),
+		X:     new(big.Int).Set(validPublicKey.X),
+		Y:     new(big.Int).Add(validPublicKey.Y, big.NewInt(2)),
+	}
+	require.False(t, invalidPublicKey.Validate())
+	require.Equal(t, validPublicKey.Compressed(), invalidPublicKey.Compressed())
+	require.False(t, signature.Verify(digest[:], invalidPublicKey))
 
 	invalidDigest := digest
 	invalidDigest[0] ^= 0x01

--- a/transaction/bdk/doc.go
+++ b/transaction/bdk/doc.go
@@ -1,0 +1,11 @@
+// Package bdk adapts go-sdk transactions and secp256k1 signatures to GoBDK's
+// native implementations.
+//
+// GoBDK ships prebuilt native libraries. The native API is available only with
+// CGO on supported Linux and macOS amd64/arm64 targets. On other targets this
+// package remains discoverable for documentation and repository-wide tooling,
+// but exposes no native implementation.
+//
+// Importing the package does not change SDK behavior; callers must explicitly
+// install the signature backend or construct a Validator.
+package bdk


### PR DESCRIPTION
Add an opt-in GoBDK transaction validator and a process-wide secp256k1 backend at the shared EC primitives. Keep the pure-Go defaults and exclude native bindings when CGO or a supported platform is unavailable.
