### PR TITLE
test: raise coverage into the 90s (config exclusions + error-path tests)

### DIFF
--- a/.github/env/90-project.env
+++ b/.github/env/90-project.env
@@ -36,7 +36,7 @@ CODECOV_TOKEN_REQUIRED=true
 # ================================================================================================
 # Paths excluded from coverage reporting (aligned with codecov.yml ignore patterns)
 
-GO_COVERAGE_EXCLUDE_PATHS=.github/,.mage-cache/,.vscode/,bin/,example/,examples/,mocks/,testing/,test/,vendor/,testdata/
+GO_COVERAGE_EXCLUDE_PATHS=.github/,.mage-cache/,.vscode/,bin/,docs/,example/,examples/,mocks/,testing/,test/,vendor/,testdata/,test_util/,test_cert_util/,testcertificates/,test_wallet.go,test_logger.go,mock.go
 
 # ================================================================================================
 # 🛡️ SECURITY EXCLUSIONS

--- a/auth/authpayload/http_extra_test.go
+++ b/auth/authpayload/http_extra_test.go
@@ -1,0 +1,236 @@
+package authpayload_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/auth/authpayload"
+	"github.com/bsv-blockchain/go-sdk/util"
+)
+
+// errReadCloser is an io.ReadCloser whose Read always fails, used to exercise
+// body-read error branches.
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("boom read") }
+
+func (errReadCloser) Close() error { return nil }
+
+func TestToHTTPRequestWithBaseURL(t *testing.T) {
+	// given: a serialized request with a path and query params
+	requestID := bytes.Repeat([]byte{1}, 32)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://ignored/api/resource?x=1", nil)
+	require.NoError(t, err)
+
+	payload, err := authpayload.FromHTTPRequest(requestID, req)
+	require.NoError(t, err)
+
+	// when: deserializing with a base URL option
+	const baseURL = "https://base.example.com"
+	gotID, gotReq, err := authpayload.ToHTTPRequest(payload, authpayload.WithBaseURL(baseURL))
+
+	// then:
+	require.NoError(t, err)
+	assert.Equal(t, requestID, gotID)
+	assert.Equal(t, "base.example.com", gotReq.URL.Host)
+	assert.Equal(t, "https", gotReq.URL.Scheme)
+	assert.Equal(t, "/api/resource", gotReq.URL.Path)
+	assert.Equal(t, "x=1", gotReq.URL.RawQuery)
+}
+
+func TestToHTTPRequestDeserializationErrorBranches(t *testing.T) {
+	requestID := bytes.Repeat([]byte{7}, 32)
+
+	tests := map[string]struct {
+		payload []byte
+		errMsg  string
+	}{
+		"error reading method": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				return w.Buf
+			}(),
+			errMsg: "failed to read method from payload",
+		},
+		"error reading path": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				return w.Buf
+			}(),
+			errMsg: "failed to read path from payload",
+		},
+		"error reading search params": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				w.WriteString("/api")
+				return w.Buf
+			}(),
+			errMsg: "failed to read search params from payload",
+		},
+		"error creating url from invalid escape": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				w.WriteString("%zz") // invalid percent-escape -> url.Parse fails
+				w.WriteOptionalString("")
+				return w.Buf
+			}(),
+			errMsg: "failed to create url from payload",
+		},
+		"error reading number of headers": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				w.WriteString("/api")
+				w.WriteOptionalString("")
+				return w.Buf
+			}(),
+			errMsg: "failed to read number of headers",
+		},
+		"error reading header name": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				w.WriteString("/api")
+				w.WriteOptionalString("")
+				w.WriteVarInt(1) // claim one header but write nothing
+				return w.Buf
+			}(),
+			errMsg: "name from payload",
+		},
+		"error reading header value": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				w.WriteString("/api")
+				w.WriteOptionalString("")
+				w.WriteVarInt(1)
+				w.WriteString("x-bsv-test") // header name but no value
+				return w.Buf
+			}(),
+			errMsg: "value from payload",
+		},
+		"error reading body": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteString(http.MethodGet)
+				w.WriteString("/api")
+				w.WriteOptionalString("")
+				w.WriteVarInt(0) // no headers, then no body bytes
+				return w.Buf
+			}(),
+			errMsg: "failed to read body from payload",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotID, gotReq, err := authpayload.ToHTTPRequest(tc.payload)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errMsg)
+			assert.Nil(t, gotID)
+			assert.Nil(t, gotReq)
+		})
+	}
+}
+
+func TestFromHTTPRequestBodyReadError(t *testing.T) {
+	requestID := bytes.Repeat([]byte{1}, 32)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com/api", nil)
+	require.NoError(t, err)
+	req.Body = errReadCloser{}
+
+	payload, err := authpayload.FromHTTPRequest(requestID, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read request body")
+	assert.Nil(t, payload)
+}
+
+func TestFromHTTPResponseBodyReadError(t *testing.T) {
+	requestID := bytes.Repeat([]byte{1}, 32)
+	res := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       errReadCloser{},
+	}
+
+	payload, err := authpayload.FromHTTPResponse(requestID, res)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read response body")
+	assert.Nil(t, payload)
+}
+
+func TestToSimplifiedHTTPResponseErrorBranches(t *testing.T) {
+	requestID := bytes.Repeat([]byte{5}, 32)
+
+	tests := map[string]struct {
+		payload []byte
+		errMsg  string
+	}{
+		"error reading status code": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				return w.Buf
+			}(),
+			errMsg: "failed to read status code",
+		},
+		"error reading header key": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteVarInt(uint64(http.StatusOK))
+				w.WriteVarInt(1) // one header but no key
+				return w.Buf
+			}(),
+			errMsg: "key to create http response",
+		},
+		"error reading header value": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteVarInt(uint64(http.StatusOK))
+				w.WriteVarInt(1)
+				w.WriteString("x-bsv-test") // key present but no value
+				return w.Buf
+			}(),
+			errMsg: "value to create http response",
+		},
+		"error reading body": {
+			payload: func() []byte {
+				w := util.NewWriter()
+				w.WriteBytes(requestID)
+				w.WriteVarInt(uint64(http.StatusOK))
+				w.WriteVarInt(0) // no headers, then no body bytes
+				return w.Buf
+			}(),
+			errMsg: "failed to read body",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotID, res, err := authpayload.ToSimplifiedHttpResponse(tc.payload)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errMsg)
+			assert.Nil(t, gotID)
+			assert.Empty(t, res.Body)
+		})
+	}
+}

--- a/auth/certificates/master_extra_test.go
+++ b/auth/certificates/master_extra_test.go
@@ -1,0 +1,397 @@
+package certificates_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/auth/certificates"
+	"github.com/bsv-blockchain/go-sdk/auth/utils"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+var errBoom = errors.New("boom")
+
+func TestNewMasterCertificateErrors(t *testing.T) {
+	subjectKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	certifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	t.Run("missing keyring entry for a field", func(t *testing.T) {
+		baseCert := &certificates.Certificate{
+			Type:         utils.RandomBase64(32),
+			SerialNumber: utils.RandomBase64(32),
+			Subject:      *subjectKey.PubKey(),
+			Certifier:    *certifierKey.PubKey(),
+			Fields: map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{
+				"name": "encrypted-value",
+			},
+		}
+		// keyring is non-empty but is missing the "name" field
+		masterKeyring := map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{
+			"other": "some-key",
+		}
+
+		_, err := certificates.NewMasterCertificate(baseCert, masterKeyring)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "master keyring must contain a value for every field")
+	})
+}
+
+func TestCreateCertificateFieldsErrors(t *testing.T) {
+	t.Run("wallet encrypt failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnEncrypt().ReturnError(errBoom)
+
+		_, err := certificates.CreateCertificateFields(
+			t.Context(),
+			tw,
+			wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+			map[wallet.CertificateFieldNameUnder50Bytes]string{"name": "Alice"},
+			false,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to encrypt field revelation key")
+	})
+}
+
+func TestIssueCertificateForSubjectErrors(t *testing.T) {
+	subjectKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	subjectCounterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: subjectKey.PubKey()}
+
+	certType := string(utils.RandomBase64(32))
+
+	t.Run("field name exceeds 50 bytes", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		longName := "this-field-name-is-definitely-longer-than-fifty-bytes-limit"
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			subjectCounterparty,
+			map[string]string{longName: "value"},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds 50 bytes limit")
+	})
+
+	t.Run("create certificate fields failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnEncrypt().ReturnError(errBoom)
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create certificate fields")
+	})
+
+	t.Run("get certifier public key failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnGetPublicKey().ReturnError(errBoom)
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get certifier public key")
+	})
+
+	t.Run("certifier public key is not valid", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		// Return a non-nil result whose PublicKey has a nil X coordinate.
+		tw.OnGetPublicKey().ReturnSuccess(&wallet.GetPublicKeyResult{PublicKey: &ec.PublicKey{}})
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get a valid certifier public key")
+	})
+
+	t.Run("revocation outpoint func failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			certType,
+			func(string) (*transaction.Outpoint, error) { return nil, errBoom },
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get revocation outpoint")
+	})
+
+	t.Run("subject TypeOther with nil counterparty", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		// Empty fields so field encryption (which uses the subject counterparty) is skipped
+		// and the counterparty-type switch is reached.
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: nil},
+			map[string]string{},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "nil public key")
+	})
+
+	t.Run("subject TypeAnyone succeeds using certifier key", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		cert, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			wallet.Counterparty{Type: wallet.CounterpartyTypeAnyone},
+			map[string]string{"name": "Alice"},
+			certType,
+			nil,
+			"",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+	})
+
+	t.Run("subject uninitialized counterparty", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			wallet.Counterparty{Type: wallet.CounterpartyUninitialized},
+			map[string]string{},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unhandled subject counterparty type")
+	})
+
+	t.Run("subject unknown counterparty type", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			wallet.Counterparty{Type: wallet.CounterpartyType(99)},
+			map[string]string{},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unhandled subject counterparty type")
+	})
+
+	t.Run("sign failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnCreateSignature().ReturnError(errBoom)
+		_, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			tw,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			certType,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to sign certificate")
+	})
+}
+
+func TestDecryptFieldErrors(t *testing.T) {
+	fieldName := wallet.CertificateFieldNameUnder50Bytes("name")
+	certifierCounterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeSelf}
+
+	t.Run("empty master keyring", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.DecryptField(
+			t.Context(), tw,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{},
+			fieldName, "value", certifierCounterparty, false, "",
+		)
+		require.ErrorIs(t, err, certificates.ErrMissingMasterKeyring)
+	})
+
+	t.Run("field key not in keyring", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.DecryptField(
+			t.Context(), tw,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{"other": "key"},
+			fieldName, "value", certifierCounterparty, false, "",
+		)
+		require.ErrorIs(t, err, certificates.ErrKeyNotFoundInKeyring)
+	})
+
+	t.Run("master key base64 decode failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.DecryptField(
+			t.Context(), tw,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{fieldName: "!!!not-base64!!!"},
+			fieldName, "value", certifierCounterparty, false, "",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode master key")
+	})
+
+	t.Run("encrypted field value base64 decode failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		// Let decryption of the revelation key succeed with a 32-byte key.
+		tw.OnDecrypt().ReturnSuccess(&wallet.DecryptResult{Plaintext: make([]byte, 32)})
+		validBase64Key := wallet.StringBase64(base64.StdEncoding.EncodeToString([]byte("some-encrypted-key-bytes")))
+		_, err := certificates.DecryptField(
+			t.Context(), tw,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{fieldName: validBase64Key},
+			fieldName, "!!!not-base64!!!", certifierCounterparty, false, "",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode encrypted field value")
+	})
+
+	t.Run("symmetric decryption failure", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnDecrypt().ReturnSuccess(&wallet.DecryptResult{Plaintext: make([]byte, 32)})
+		validBase64Key := wallet.StringBase64(base64.StdEncoding.EncodeToString([]byte("some-encrypted-key-bytes")))
+		// A valid base64 string that is garbage as ciphertext, so symmetric decrypt fails.
+		garbageValue := wallet.StringBase64(base64.StdEncoding.EncodeToString([]byte("garbage-ciphertext-that-cannot-be-decrypted")))
+		_, err := certificates.DecryptField(
+			t.Context(), tw,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{fieldName: validBase64Key},
+			fieldName, garbageValue, certifierCounterparty, false, "",
+		)
+		require.ErrorIs(t, err, certificates.ErrDecryptionFailed)
+	})
+}
+
+func TestDecryptFieldsErrors(t *testing.T) {
+	t.Run("nil fields map", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		_, err := certificates.DecryptFields(
+			t.Context(), tw,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{"name": "key"},
+			nil,
+			wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+			false, "",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fields map cannot be nil")
+	})
+}
+
+func TestCreateKeyringForVerifierErrors(t *testing.T) {
+	subjectKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	certifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	certifierWallet, err := wallet.NewCompletedProtoWallet(certifierKey)
+	require.NoError(t, err)
+
+	subjectCounterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: subjectKey.PubKey()}
+	certifierCounterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: certifierKey.PubKey()}
+	verifierCounterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: verifierKey.PubKey()}
+
+	t.Run("empty master keyring", func(t *testing.T) {
+		subjectWallet, err := wallet.NewCompletedProtoWallet(subjectKey)
+		require.NoError(t, err)
+		_, err = certificates.CreateKeyringForVerifier(
+			t.Context(), subjectWallet, certifierCounterparty, verifierCounterparty,
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{},
+			[]wallet.CertificateFieldNameUnder50Bytes{"name"},
+			map[wallet.CertificateFieldNameUnder50Bytes]wallet.StringBase64{},
+			"serial", false, "",
+		)
+		require.ErrorIs(t, err, certificates.ErrMissingMasterKeyring)
+	})
+
+	t.Run("encrypt for verifier failure", func(t *testing.T) {
+		// Issue a real certificate so DecryptField succeeds against the real subject key,
+		// but wrap the subject wallet so the re-encryption for the verifier fails.
+		issued, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			certifierWallet,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			string(utils.RandomBase64(32)),
+			nil,
+			"",
+		)
+		require.NoError(t, err)
+
+		subjectTestWallet := wallet.NewTestWallet(t, subjectKey)
+		subjectTestWallet.OnEncrypt().ReturnError(errBoom)
+
+		_, err = certificates.CreateKeyringForVerifier(
+			t.Context(),
+			subjectTestWallet,
+			certifierCounterparty,
+			verifierCounterparty,
+			issued.Fields,
+			[]wallet.CertificateFieldNameUnder50Bytes{"name"},
+			issued.MasterKeyring,
+			issued.SerialNumber,
+			false, "",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to encrypt field key for verifier")
+	})
+
+	t.Run("field to reveal not present", func(t *testing.T) {
+		issued, err := certificates.IssueCertificateForSubject(
+			t.Context(),
+			certifierWallet,
+			subjectCounterparty,
+			map[string]string{"name": "Alice"},
+			string(utils.RandomBase64(32)),
+			nil,
+			"",
+		)
+		require.NoError(t, err)
+
+		subjectWallet, err := wallet.NewCompletedProtoWallet(subjectKey)
+		require.NoError(t, err)
+
+		_, err = certificates.CreateKeyringForVerifier(
+			t.Context(),
+			subjectWallet,
+			certifierCounterparty,
+			verifierCounterparty,
+			issued.Fields,
+			[]wallet.CertificateFieldNameUnder50Bytes{"nonexistent"},
+			issued.MasterKeyring,
+			issued.SerialNumber,
+			false, "",
+		)
+		require.ErrorIs(t, err, certificates.ErrFieldNotFound)
+	})
+}

--- a/auth/clients/authhttp/authhttp_extra2_test.go
+++ b/auth/clients/authhttp/authhttp_extra2_test.go
@@ -1,0 +1,86 @@
+package clients
+
+// authhttp_extra2_test.go exercises the certificate-requested listener body
+// inside Fetch's goroutine (authhttp.go ~lines 285-303). That closure only runs
+// when the server, during the handshake, asks the client for certificates. We
+// drive it deterministically by standing up a BRC-31 server whose peer is
+// configured with a non-empty CertificatesToRequest, then making the client's
+// wallet fail ListCertificates so utils.GetVerifiableCertificates returns an
+// error and the listener returns early.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/auth"
+	"github.com/bsv-blockchain/go-sdk/auth/utils"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// buildCertRequestingServer stands up a BRC-31 httptest.Server whose auth peer
+// requests certificates from every counterparty during the handshake. Because
+// only Certifiers (not CertificateTypes) are requested, the server session
+// stays authenticated, but its initialResponse still carries a non-empty
+// RequestedCertificates set — which triggers the client's certificate-requested
+// listener when it processes that response.
+func buildCertRequestingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	serverKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	serverWallet := wallet.NewTestWallet(t, serverKey)
+
+	serverSM := auth.NewSessionManager()
+
+	ct := newChannelTransport()
+	auth.NewPeer(&auth.PeerOptions{
+		Wallet:         serverWallet,
+		Transport:      ct,
+		SessionManager: serverSM,
+		CertificatesToRequest: &utils.RequestedCertificateSet{
+			Certifiers:       []*ec.PublicKey{serverKey.PubKey()},
+			CertificateTypes: make(utils.RequestedCertificateTypeIDAndFieldList),
+		},
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(wellKnownAuthPath, buildAuthInitHandler(ct))
+	// A general-message handler is required for the mux, but the handshake fails
+	// before any general message is sent in this test.
+	mux.HandleFunc("/", buildGeneralMessageHandler(ct, serverSM, serverWallet, http.StatusOK))
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestFetchCertificateRequestedListenerGetVerifiableCertsError covers the
+// certificate-requested listener body up to the GetVerifiableCertificates error
+// return: the server asks for certificates, and the client's wallet fails to
+// list them, so the listener returns the error and the handshake fails.
+func TestFetchCertificateRequestedListenerGetVerifiableCertsError(t *testing.T) {
+	ts := buildCertRequestingServer(t)
+
+	clientWallet := wallet.NewTestWalletForRandomKey(t)
+	clientWallet.OnListCertificates().ReturnError(errors.New("boom listing certs"))
+
+	af := New(clientWallet, WithoutLogging())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := af.Fetch(ctx, ts.URL+"/data", &SimplifiedFetchRequestOptions{Method: "GET"})
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom listing certs")
+}

--- a/auth/peer_errors_extra_test.go
+++ b/auth/peer_errors_extra_test.go
@@ -1,0 +1,783 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/auth"
+	"github.com/bsv-blockchain/go-sdk/auth/certificates"
+	"github.com/bsv-blockchain/go-sdk/auth/utils"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-sdk/wallet/testcertificates"
+)
+
+var errBoom = errors.New("boom")
+
+// failingOnDataTransport is a transport whose OnData always fails, used to
+// exercise the peer's Start error handling.
+type failingOnDataTransport struct{}
+
+func (failingOnDataTransport) Send(context.Context, *auth.AuthMessage) error { return nil }
+
+func (failingOnDataTransport) OnData(func(context.Context, *auth.AuthMessage) error) error {
+	return errBoom
+}
+
+func (failingOnDataTransport) GetRegisteredOnData() (func(context.Context, *auth.AuthMessage) error, error) {
+	return nil, errBoom
+}
+
+// acceptTransport accepts every Send without ever delivering a response, so a
+// peer that initiates a handshake over it will time out waiting for a reply.
+type acceptTransport struct {
+	handler func(context.Context, *auth.AuthMessage) error
+}
+
+func (a *acceptTransport) Send(context.Context, *auth.AuthMessage) error { return nil }
+
+func (a *acceptTransport) OnData(cb func(context.Context, *auth.AuthMessage) error) error {
+	a.handler = cb
+	return nil
+}
+
+func (a *acceptTransport) GetRegisteredOnData() (func(context.Context, *auth.AuthMessage) error, error) {
+	return a.handler, nil
+}
+
+// newHandlerPeer builds a peer wired to a plain MockTransport and returns the
+// registered incoming-message handler so tests can feed it crafted messages
+// directly, exercising the internal message handlers.
+func newHandlerPeer(t *testing.T) (*wallet.TestWallet, auth.SessionManager, func(context.Context, *auth.AuthMessage) error) {
+	t.Helper()
+	priv, err := ec.PrivateKeyFromHex(bobPrivKeyHex)
+	require.NoError(t, err)
+
+	w := wallet.NewTestWallet(t, priv, wallet.WithTestWalletName("receiver"))
+	tr := NewMockTransport("receiver")
+	sm := auth.NewSessionManager()
+	// The registered handler closes over the peer, keeping it alive.
+	auth.NewPeer(&auth.PeerOptions{
+		Wallet:         w,
+		Transport:      tr,
+		SessionManager: sm,
+	})
+
+	handler, err := tr.GetRegisteredOnData()
+	require.NoError(t, err)
+	return w, sm, handler
+}
+
+func mustDecodeB64(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := base64.StdEncoding.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+func TestNewPeerAndStartErrorPaths(t *testing.T) {
+	t.Run("NewPeer applies configured CertificatesToRequest", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+
+		certReq := &utils.RequestedCertificateSet{
+			Certifiers: []*ec.PublicKey{priv.PubKey()},
+			CertificateTypes: utils.RequestedCertificateTypeIDAndFieldList{
+				wallet.CertificateType{}: []string{emailField},
+			},
+		}
+
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:                w,
+			Transport:             NewMockTransport("test"),
+			CertificatesToRequest: certReq,
+		})
+		assert.Same(t, certReq, peer.CertificatesToRequest)
+	})
+
+	t.Run("NewPeer tolerates transport that fails to register handler", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+
+		// Must not panic even though Start fails internally.
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:    w,
+			Transport: failingOnDataTransport{},
+		})
+		require.NotNil(t, peer)
+	})
+
+	t.Run("Start returns error when transport OnData fails", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:    w,
+			Transport: failingOnDataTransport{},
+		})
+		err = peer.Start()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to register message handler")
+	})
+}
+
+func TestHandleIncomingMessageBranches(t *testing.T) {
+	_, _, handler := newHandlerPeer(t)
+	ctx := t.Context()
+
+	priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+	require.NoError(t, err)
+
+	t.Run("nil message is rejected", func(t *testing.T) {
+		err := handler(ctx, nil)
+		require.ErrorIs(t, err, auth.ErrInvalidMessage)
+	})
+
+	t.Run("unsupported version is rejected", func(t *testing.T) {
+		err := handler(ctx, &auth.AuthMessage{
+			Version:     "9.9",
+			MessageType: auth.MessageTypeGeneral,
+			IdentityKey: priv.PubKey(),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid or unsupported message auth version")
+	})
+
+	t.Run("unknown message type is rejected", func(t *testing.T) {
+		err := handler(ctx, &auth.AuthMessage{
+			Version:     auth.AUTH_VERSION,
+			MessageType: auth.MessageType("bogus"),
+			IdentityKey: priv.PubKey(),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown message type")
+	})
+}
+
+func TestHandleInitialRequestErrorPaths(t *testing.T) {
+	sender, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+	require.NoError(t, err)
+	senderPub := sender.PubKey()
+
+	validNonce := string(utils.RandomBase64(32))
+
+	t.Run("empty initial nonce is rejected", func(t *testing.T) {
+		_, _, handler := newHandlerPeer(t)
+		err := handler(t.Context(), &auth.AuthMessage{
+			Version:      auth.AUTH_VERSION,
+			MessageType:  auth.MessageTypeInitialRequest,
+			IdentityKey:  senderPub,
+			InitialNonce: "",
+		})
+		require.ErrorIs(t, err, auth.ErrInvalidNonce)
+	})
+
+	t.Run("create session nonce failure", func(t *testing.T) {
+		w, _, handler := newHandlerPeer(t)
+		w.OnCreateHMAC().ReturnError(errBoom)
+		err := handler(t.Context(), &auth.AuthMessage{
+			Version:      auth.AUTH_VERSION,
+			MessageType:  auth.MessageTypeInitialRequest,
+			IdentityKey:  senderPub,
+			InitialNonce: validNonce,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create session nonce")
+	})
+
+	t.Run("get identity key failure", func(t *testing.T) {
+		w, _, handler := newHandlerPeer(t)
+		w.OnGetPublicKey().ReturnError(errBoom)
+		err := handler(t.Context(), &auth.AuthMessage{
+			Version:      auth.AUTH_VERSION,
+			MessageType:  auth.MessageTypeInitialRequest,
+			IdentityKey:  senderPub,
+			InitialNonce: validNonce,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get identity key")
+	})
+
+	t.Run("undecodable initial nonce is rejected", func(t *testing.T) {
+		_, _, handler := newHandlerPeer(t)
+		err := handler(t.Context(), &auth.AuthMessage{
+			Version:      auth.AUTH_VERSION,
+			MessageType:  auth.MessageTypeInitialRequest,
+			IdentityKey:  senderPub,
+			InitialNonce: "@@@not-base64@@@",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode initial nonce")
+	})
+
+	t.Run("sign initial response failure", func(t *testing.T) {
+		w, _, handler := newHandlerPeer(t)
+		w.OnCreateSignature().ReturnError(errBoom)
+		err := handler(t.Context(), &auth.AuthMessage{
+			Version:      auth.AUTH_VERSION,
+			MessageType:  auth.MessageTypeInitialRequest,
+			IdentityKey:  senderPub,
+			InitialNonce: validNonce,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to sign initial response")
+	})
+}
+
+// nonGeneralOrInitialResponse groups the message types whose handlers share the
+// nonce-verify / session-lookup / signature-parse error scaffolding.
+func authMessageTypesForErrors() []auth.MessageType {
+	return []auth.MessageType{
+		auth.MessageTypeInitialResponse,
+		auth.MessageTypeCertificateRequest,
+		auth.MessageTypeCertificateResponse,
+		auth.MessageTypeGeneral,
+	}
+}
+
+func TestHandleMessageNonceErrors(t *testing.T) {
+	sender, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+	require.NoError(t, err)
+	senderPub := sender.PubKey()
+
+	t.Run("undecodable your-nonce fails validation", func(t *testing.T) {
+		_, _, handler := newHandlerPeer(t)
+		for _, mt := range authMessageTypesForErrors() {
+			t.Run(string(mt), func(t *testing.T) {
+				err := handler(t.Context(), &auth.AuthMessage{
+					Version:     auth.AUTH_VERSION,
+					MessageType: mt,
+					IdentityKey: senderPub,
+					YourNonce:   "@@@not-base64@@@",
+				})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to validate nonce")
+			})
+		}
+	})
+
+	t.Run("well-formed but foreign nonce is invalid", func(t *testing.T) {
+		w, _, handler := newHandlerPeer(t)
+		// Force VerifyHMAC to report a mismatch without error.
+		w.OnVerifyHMAC().ReturnSuccess(&wallet.VerifyHMACResult{Valid: false})
+		for _, mt := range authMessageTypesForErrors() {
+			t.Run(string(mt), func(t *testing.T) {
+				err := handler(t.Context(), &auth.AuthMessage{
+					Version:     auth.AUTH_VERSION,
+					MessageType: mt,
+					IdentityKey: senderPub,
+					YourNonce:   string(utils.RandomBase64(32)),
+				})
+				require.ErrorIs(t, err, auth.ErrInvalidNonce)
+			})
+		}
+	})
+
+	t.Run("missing session is rejected", func(t *testing.T) {
+		w, _, handler := newHandlerPeer(t)
+		// A nonce created by this wallet passes verification but no session exists.
+		yourNonce, err := utils.CreateNonce(t.Context(), w, wallet.Counterparty{Type: wallet.CounterpartyTypeSelf})
+		require.NoError(t, err)
+		for _, mt := range authMessageTypesForErrors() {
+			t.Run(string(mt), func(t *testing.T) {
+				err := handler(t.Context(), &auth.AuthMessage{
+					Version:     auth.AUTH_VERSION,
+					MessageType: mt,
+					IdentityKey: senderPub,
+					YourNonce:   yourNonce,
+				})
+				require.ErrorIs(t, err, auth.ErrSessionNotFound)
+			})
+		}
+	})
+}
+
+func TestHandleMessageSignatureErrors(t *testing.T) {
+	sender, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+	require.NoError(t, err)
+	senderPub := sender.PubKey()
+
+	t.Run("unparseable signature is rejected", func(t *testing.T) {
+		w, sm, handler := newHandlerPeer(t)
+		ctx := t.Context()
+		sessionNonce, err := utils.CreateNonce(ctx, w, wallet.Counterparty{Type: wallet.CounterpartyTypeSelf})
+		require.NoError(t, err)
+		require.NoError(t, sm.AddSession(&auth.PeerSession{
+			SessionNonce:    sessionNonce,
+			PeerNonce:       string(utils.RandomBase64(32)),
+			PeerIdentityKey: senderPub,
+			IsAuthenticated: true,
+			LastUpdate:      time.Now().UnixMilli(),
+		}))
+
+		for _, mt := range authMessageTypesForErrors() {
+			t.Run(string(mt), func(t *testing.T) {
+				err := handler(ctx, &auth.AuthMessage{
+					Version:      auth.AUTH_VERSION,
+					MessageType:  mt,
+					IdentityKey:  senderPub,
+					YourNonce:    sessionNonce,
+					InitialNonce: string(utils.RandomBase64(32)),
+					Signature:    []byte("not-a-signature"),
+				})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to parse signature")
+			})
+		}
+	})
+
+	// Helper that builds a peer with a session and a parseable signature, then
+	// applies a VerifySignature override to exercise the verify branches.
+	setup := func(t *testing.T) (auth.SessionManager, string, []byte, *wallet.TestWallet, func(context.Context, *auth.AuthMessage) error) {
+		t.Helper()
+		w, sm, handler := newHandlerPeer(t)
+		ctx := t.Context()
+		sessionNonce, err := utils.CreateNonce(ctx, w, wallet.Counterparty{Type: wallet.CounterpartyTypeSelf})
+		require.NoError(t, err)
+		require.NoError(t, sm.AddSession(&auth.PeerSession{
+			SessionNonce:    sessionNonce,
+			PeerNonce:       string(utils.RandomBase64(32)),
+			PeerIdentityKey: senderPub,
+			IsAuthenticated: true,
+			LastUpdate:      time.Now().UnixMilli(),
+		}))
+
+		sigRes, err := w.CreateSignature(ctx, wallet.CreateSignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{
+				ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryAppAndCounterparty, Protocol: auth.AUTH_PROTOCOL_ID},
+				KeyID:        "x",
+				Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeAnyone},
+			},
+			Data: []byte("dummy"),
+		}, "")
+		require.NoError(t, err)
+		return sm, sessionNonce, sigRes.Signature.Serialize(), w, handler
+	}
+
+	t.Run("verify signature error", func(t *testing.T) {
+		_, sessionNonce, validSig, w, handler := setup(t)
+		ctx := t.Context()
+		w.OnVerifySignature().ReturnError(errBoom)
+		for _, mt := range authMessageTypesForErrors() {
+			t.Run(string(mt), func(t *testing.T) {
+				err := handler(ctx, &auth.AuthMessage{
+					Version:      auth.AUTH_VERSION,
+					MessageType:  mt,
+					IdentityKey:  senderPub,
+					YourNonce:    sessionNonce,
+					InitialNonce: string(utils.RandomBase64(32)),
+					Signature:    validSig,
+				})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to verify signature")
+			})
+		}
+	})
+
+	t.Run("invalid signature is rejected", func(t *testing.T) {
+		_, sessionNonce, validSig, w, handler := setup(t)
+		ctx := t.Context()
+		w.OnVerifySignature().ReturnSuccess(&wallet.VerifySignatureResult{Valid: false})
+		for _, mt := range authMessageTypesForErrors() {
+			t.Run(string(mt), func(t *testing.T) {
+				err := handler(ctx, &auth.AuthMessage{
+					Version:      auth.AUTH_VERSION,
+					MessageType:  mt,
+					IdentityKey:  senderPub,
+					YourNonce:    sessionNonce,
+					InitialNonce: string(utils.RandomBase64(32)),
+					Signature:    validSig,
+				})
+				require.ErrorIs(t, err, auth.ErrInvalidSignature)
+			})
+		}
+	})
+}
+
+// buildInitialResponseWithCerts constructs a valid initial-response message from
+// bob to alice carrying the supplied certificates, signed by bob's wallet so
+// alice accepts it. It mirrors what a spec-compliant peer embeds in an initial
+// response.
+func buildInitialResponseWithCerts(
+	t *testing.T,
+	ctx context.Context,
+	aliceWallet *wallet.TestWallet,
+	aliceSM auth.SessionManager,
+	alicePub *ec.PublicKey,
+	bob *Actor,
+	certs []*certificates.VerifiableCertificate,
+) *auth.AuthMessage {
+	t.Helper()
+
+	aliceNonce, err := utils.CreateNonce(ctx, aliceWallet, wallet.Counterparty{Type: wallet.CounterpartyTypeSelf})
+	require.NoError(t, err)
+	bobNonce, err := utils.CreateNonce(ctx, bob.Wallet, wallet.Counterparty{Type: wallet.CounterpartyTypeSelf})
+	require.NoError(t, err)
+
+	require.NoError(t, aliceSM.AddSession(&auth.PeerSession{
+		SessionNonce:    aliceNonce,
+		PeerIdentityKey: bob.IdentityKey,
+		LastUpdate:      time.Now().UnixMilli(),
+	}))
+
+	sigData := append(mustDecodeB64(t, aliceNonce), mustDecodeB64(t, bobNonce)...)
+	// Bob signs the concatenated nonces addressed to Alice, matching what a peer
+	// produces for an initial response.
+	sigRes, err := bob.Wallet.CreateSignature(ctx, wallet.CreateSignatureArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryAppAndCounterparty, Protocol: auth.AUTH_PROTOCOL_ID},
+			KeyID:        fmt.Sprintf("%s %s", aliceNonce, bobNonce),
+			Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: alicePub},
+		},
+		Data: sigData,
+	}, "")
+	require.NoError(t, err)
+
+	return &auth.AuthMessage{
+		Version:      auth.AUTH_VERSION,
+		MessageType:  auth.MessageTypeInitialResponse,
+		IdentityKey:  bob.IdentityKey,
+		Nonce:        bobNonce,
+		YourNonce:    aliceNonce,
+		InitialNonce: bobNonce,
+		Signature:    sigRes.Signature.Serialize(),
+		Certificates: certs,
+	}
+}
+
+func TestHandleInitialResponseWithCertificates(t *testing.T) {
+	// Bob only needs a wallet + certificate manager; his peer/transport are unused.
+	bob := NewActor(t, bobName, bobPrivKeyHex)
+	bobCertManager := testcertificates.NewManager(t, bob.Wallet)
+	bobsCert := bobCertManager.CertificateForTest().WithType(contactCertTypeName).
+		WithFieldValue(emailField, bobName+"@example.com").
+		Issue()
+
+	certReq := &utils.RequestedCertificateSet{
+		Certifiers: []*ec.PublicKey{bobsCert.WalletCert.Certifier},
+		CertificateTypes: utils.RequestedCertificateTypeIDAndFieldList{
+			bobsCert.WalletCert.Type: []string{emailField},
+		},
+	}
+
+	t.Run("valid embedded certificates authenticate the session", func(t *testing.T) {
+		alicePriv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		aliceWallet := wallet.NewTestWallet(t, alicePriv, wallet.WithTestWalletName(aliceName))
+		aliceTr := NewMockTransport(aliceName)
+		aliceSM := auth.NewSessionManager()
+		alice := auth.NewPeer(&auth.PeerOptions{
+			Wallet:                aliceWallet,
+			Transport:             aliceTr,
+			SessionManager:        aliceSM,
+			CertificatesToRequest: certReq,
+		})
+		handler, err := aliceTr.GetRegisteredOnData()
+		require.NoError(t, err)
+
+		var received bool
+		alice.ListenForCertificatesReceived(func(_ context.Context, _ *ec.PublicKey, certs []*certificates.VerifiableCertificate) error {
+			received = true
+			assert.Len(t, certs, 1)
+			return nil
+		})
+
+		verifiableCert := bobsCert.ToVerifiableCertificate(alicePriv.PubKey())
+		ctx := t.Context()
+		msg := buildInitialResponseWithCerts(t, ctx, aliceWallet, aliceSM, alicePriv.PubKey(), bob, []*certificates.VerifiableCertificate{verifiableCert})
+
+		err = handler(ctx, msg)
+		require.NoError(t, err)
+		require.True(t, received, "certificate-received callback must fire")
+
+		session, err := aliceSM.GetSession(msg.YourNonce)
+		require.NoError(t, err)
+		require.True(t, session.IsAuthenticated)
+	})
+
+	t.Run("invalid embedded certificates are rejected", func(t *testing.T) {
+		alicePriv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		aliceWallet := wallet.NewTestWallet(t, alicePriv, wallet.WithTestWalletName(aliceName))
+		aliceTr := NewMockTransport(aliceName)
+		aliceSM := auth.NewSessionManager()
+		auth.NewPeer(&auth.PeerOptions{
+			Wallet:                aliceWallet,
+			Transport:             aliceTr,
+			SessionManager:        aliceSM,
+			CertificatesToRequest: certReq,
+		})
+		handler, err := aliceTr.GetRegisteredOnData()
+		require.NoError(t, err)
+
+		verifiableCert := bobsCert.ToVerifiableCertificate(alicePriv.PubKey())
+		verifiableCert.Signature = nil // break the certificate signature
+		ctx := t.Context()
+		msg := buildInitialResponseWithCerts(t, ctx, aliceWallet, aliceSM, alicePriv.PubKey(), bob, []*certificates.VerifiableCertificate{verifiableCert})
+
+		err = handler(ctx, msg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid certificates")
+	})
+}
+
+func TestToPeerErrorPaths(t *testing.T) {
+	t.Run("uses last interacted peer when identity key is nil", func(t *testing.T) {
+		alice, bob := CreateActorsPair(t)
+		bob.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bob.IdentityKey, 5000))
+
+		// Second send with a nil identity key must reuse the last peer.
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, nil, 5000))
+	})
+
+	t.Run("get identity key failure", func(t *testing.T) {
+		alice, bob := CreateActorsPair(t)
+		bob.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bob.IdentityKey, 5000))
+
+		alice.Wallet.OnGetPublicKey().ReturnError(errBoom)
+		err := alice.ToPeer(t.Context(), anyMessage, bob.IdentityKey, 5000)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get identity key")
+	})
+
+	t.Run("sign message failure", func(t *testing.T) {
+		alice, bob := CreateActorsPair(t)
+		bob.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bob.IdentityKey, 5000))
+
+		alice.Wallet.OnCreateSignature().ReturnError(errBoom)
+		err := alice.ToPeer(t.Context(), anyMessage, bob.IdentityKey, 5000)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to sign message")
+	})
+}
+
+func TestInitiateHandshakeErrorPaths(t *testing.T) {
+	bob, err := ec.PrivateKeyFromHex(bobPrivKeyHex)
+	require.NoError(t, err)
+	bobPub := bob.PubKey()
+
+	newAcceptPeer := func(t *testing.T) *auth.Peer {
+		t.Helper()
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+		return auth.NewPeer(&auth.PeerOptions{
+			Wallet:         w,
+			Transport:      &acceptTransport{},
+			SessionManager: auth.NewSessionManager(),
+		})
+	}
+
+	t.Run("create session nonce failure", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+		w.OnCreateHMAC().ReturnError(errBoom)
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:         w,
+			Transport:      &acceptTransport{},
+			SessionManager: auth.NewSessionManager(),
+		})
+		err = peer.ToPeer(t.Context(), anyMessage, bobPub, 100)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create session nonce")
+	})
+
+	t.Run("get identity key failure", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+		w.OnGetPublicKey().ReturnError(errBoom)
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:         w,
+			Transport:      &acceptTransport{},
+			SessionManager: auth.NewSessionManager(),
+		})
+		err = peer.ToPeer(t.Context(), anyMessage, bobPub, 100)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get identity key")
+	})
+
+	t.Run("handshake times out without response", func(t *testing.T) {
+		peer := newAcceptPeer(t)
+		err := peer.ToPeer(t.Context(), anyMessage, bobPub, 10)
+		require.Error(t, err)
+		require.ErrorIs(t, err, auth.ErrTimeout)
+	})
+}
+
+func TestRequestCertificatesErrorPaths(t *testing.T) {
+	bob, err := ec.PrivateKeyFromHex(bobPrivKeyHex)
+	require.NoError(t, err)
+	bobPub := bob.PubKey()
+
+	reqSet := utils.RequestedCertificateSet{
+		Certifiers: []*ec.PublicKey{bobPub},
+		CertificateTypes: utils.RequestedCertificateTypeIDAndFieldList{
+			wallet.CertificateType{}: []string{emailField},
+		},
+	}
+
+	t.Run("authenticated session failure", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:         w,
+			Transport:      &acceptTransport{},
+			SessionManager: auth.NewSessionManager(),
+		})
+		err = peer.RequestCertificates(t.Context(), bobPub, reqSet, 10)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get authenticated session")
+	})
+
+	t.Run("create nonce failure", func(t *testing.T) {
+		alice, bobActor := CreateActorsPair(t)
+		bobActor.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bobActor.IdentityKey, 5000))
+
+		alice.Wallet.OnCreateHMAC().ReturnError(errBoom)
+		err := alice.RequestCertificates(t.Context(), bobActor.IdentityKey, reqSet, 5000)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create nonce")
+	})
+
+	t.Run("get identity key failure", func(t *testing.T) {
+		alice, bobActor := CreateActorsPair(t)
+		bobActor.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bobActor.IdentityKey, 5000))
+
+		alice.Wallet.OnGetPublicKey().ReturnError(errBoom)
+		err := alice.RequestCertificates(t.Context(), bobActor.IdentityKey, reqSet, 5000)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get identity key")
+	})
+
+	t.Run("sign request failure", func(t *testing.T) {
+		alice, bobActor := CreateActorsPair(t)
+		bobActor.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bobActor.IdentityKey, 5000))
+
+		alice.Wallet.OnCreateSignature().ReturnError(errBoom)
+		err := alice.RequestCertificates(t.Context(), bobActor.IdentityKey, reqSet, 5000)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to sign certificate request")
+	})
+}
+
+func TestSendCertificateResponseErrorPaths(t *testing.T) {
+	bob, err := ec.PrivateKeyFromHex(bobPrivKeyHex)
+	require.NoError(t, err)
+	bobPub := bob.PubKey()
+
+	noCerts := []*certificates.VerifiableCertificate{}
+
+	t.Run("authenticated session failure", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+		require.NoError(t, err)
+		w := wallet.NewTestWallet(t, priv)
+		peer := auth.NewPeer(&auth.PeerOptions{
+			Wallet:         w,
+			Transport:      &acceptTransport{},
+			SessionManager: auth.NewSessionManager(),
+		})
+		err = peer.SendCertificateResponse(t.Context(), bobPub, noCerts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get authenticated session")
+	})
+
+	t.Run("create nonce failure", func(t *testing.T) {
+		alice, bobActor := CreateActorsPair(t)
+		bobActor.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bobActor.IdentityKey, 5000))
+
+		alice.Wallet.OnCreateHMAC().ReturnError(errBoom)
+		err := alice.SendCertificateResponse(t.Context(), bobActor.IdentityKey, noCerts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create nonce")
+	})
+
+	t.Run("get identity key failure", func(t *testing.T) {
+		alice, bobActor := CreateActorsPair(t)
+		bobActor.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bobActor.IdentityKey, 5000))
+
+		alice.Wallet.OnGetPublicKey().ReturnError(errBoom)
+		err := alice.SendCertificateResponse(t.Context(), bobActor.IdentityKey, noCerts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get identity key")
+	})
+
+	t.Run("sign response failure", func(t *testing.T) {
+		alice, bobActor := CreateActorsPair(t)
+		bobActor.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error { return nil })
+		require.NoError(t, alice.ToPeer(t.Context(), anyMessage, bobActor.IdentityKey, 5000))
+
+		alice.Wallet.OnCreateSignature().ReturnError(errBoom)
+		err := alice.SendCertificateResponse(t.Context(), bobActor.IdentityKey, noCerts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to sign certificate response")
+	})
+}
+
+func TestHandleGeneralMessageCallbackError(t *testing.T) {
+	// A callback returning an error is logged but does not fail delivery.
+	alice, bob := CreateActorsPair(t)
+	bob.ListenForGeneralMessages(func(context.Context, *ec.PublicKey, []byte) error {
+		return errBoom
+	})
+	err := alice.ToPeer(t.Context(), anyMessage, bob.IdentityKey, 5000)
+	require.NoError(t, err)
+}
+
+func TestAuthMessageCertificateSignatureRoundTrip(t *testing.T) {
+	// Build a message whose certificate carries a base64-encoded signature so
+	// both MarshalJSON and UnmarshalJSON exercise their signature-normalisation
+	// loops.
+	priv, err := ec.PrivateKeyFromHex(alicePrivKeyHex)
+	require.NoError(t, err)
+	tw := wallet.NewTestWallet(t, priv)
+	mgr := testcertificates.NewManager(t, tw)
+	issued := mgr.CertificateForTest().WithType(contactCertTypeName).
+		WithFieldValue(emailField, "a@example.com").
+		Issue()
+
+	verifierPriv, err := ec.PrivateKeyFromHex(bobPrivKeyHex)
+	require.NoError(t, err)
+	vc := issued.ToVerifiableCertificate(verifierPriv.PubKey())
+
+	// A base64 string ("some") whose raw bytes are not a valid DER signature.
+	vc.Signature = []byte("c29tZQ==")
+
+	msg := &auth.AuthMessage{
+		Version:      auth.AUTH_VERSION,
+		MessageType:  auth.MessageTypeCertificateResponse,
+		IdentityKey:  priv.PubKey(),
+		Certificates: []*certificates.VerifiableCertificate{vc},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var restored auth.AuthMessage
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+	require.Len(t, restored.Certificates, 1)
+	require.NotEmpty(t, restored.Certificates[0].Signature)
+}

--- a/auth/utils/coverage_extra_test.go
+++ b/auth/utils/coverage_extra_test.go
@@ -1,0 +1,302 @@
+package utils_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/auth/utils"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	tcu "github.com/bsv-blockchain/go-sdk/util/test_cert_util"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// TestCreateNonceError covers the CreateHMAC error branch of CreateNonce.
+func TestCreateNonceError(t *testing.T) {
+	t.Run("returns error when wallet CreateHMAC fails", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnCreateHMAC().ReturnError(errors.New("boom"))
+
+		nonce, err := utils.CreateNonce(context.Background(), tw, wallet.Counterparty{
+			Type: wallet.CounterpartyTypeSelf,
+		})
+		require.Error(t, err)
+		assert.Empty(t, nonce)
+		require.Contains(t, err.Error(), "failed to create HMAC")
+	})
+}
+
+// TestVerifyNonceError covers the VerifyHMAC error branch of VerifyNonce.
+func TestVerifyNonceError(t *testing.T) {
+	privKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	counterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeSelf}
+
+	t.Run("returns error when wallet VerifyHMAC fails", func(t *testing.T) {
+		// Build a well-formed nonce with a real wallet first.
+		realWallet, err := wallet.NewCompletedProtoWallet(privKey)
+		require.NoError(t, err)
+		nonce, err := utils.CreateNonce(context.Background(), realWallet, counterparty)
+		require.NoError(t, err)
+
+		tw := wallet.NewTestWallet(t, privKey)
+		tw.OnVerifyHMAC().ReturnError(errors.New("verify boom"))
+
+		valid, err := utils.VerifyNonce(context.Background(), nonce, tw, counterparty)
+		require.Error(t, err)
+		assert.False(t, valid)
+		require.Contains(t, err.Error(), "failed to verify HMAC")
+	})
+}
+
+// TestCertifierInSliceNil covers the nil-certifier branch of CertifierInSlice.
+func TestCertifierInSliceNil(t *testing.T) {
+	t.Run("returns false for nil certifier", func(t *testing.T) {
+		certifiers := []*ec.PublicKey{tu.GetPKFromString("certifier1")}
+		assert.False(t, utils.CertifierInSlice(certifiers, nil))
+	})
+}
+
+// TestValidateRequestedCertificateSetNil covers the nil-request branch.
+func TestValidateRequestedCertificateSetNil(t *testing.T) {
+	t.Run("returns error for nil request", func(t *testing.T) {
+		err := utils.ValidateRequestedCertificateSet(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested certificate set is nil")
+	})
+}
+
+// TestValidateCertificateCancelledContext covers the early context-cancellation
+// branch of the exported ValidateCertificate function.
+func TestValidateCertificateCancelledContext(t *testing.T) {
+	t.Run("returns context error when context already cancelled", func(t *testing.T) {
+		subject, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+		certifier, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+		verifier, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+
+		cert := tcu.CreateValidCertificate(t, subject, certifier, verifier.PubKey())
+		verifierWallet := wallet.NewTestWallet(t, verifier)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err = utils.ValidateCertificate(ctx, verifierWallet, cert, subject.PubKey(), nil)
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+}
+
+// TestSignCertificateWithWalletForTestErrors covers the wallet-error branches.
+func TestSignCertificateWithWalletForTestErrors(t *testing.T) {
+	subject, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	cert := wallet.Certificate{
+		Type:               tu.GetByte32FromString("some_type"),
+		SerialNumber:       tu.GetByte32FromString("some_serial"),
+		Subject:            subject.PubKey(),
+		RevocationOutpoint: tu.OutpointFromString(t, "a755810c21e17183ff6db6685f0de239fd3a0a3c0d4ba7773b0b0d1748541e2b.0"),
+		Fields:             map[string]string{"field1": base64.StdEncoding.EncodeToString([]byte("value"))},
+	}
+
+	t.Run("returns error when GetPublicKey fails", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnGetPublicKey().ReturnError(errors.New("no identity key"))
+
+		_, err := utils.SignCertificateWithWalletForTest(context.Background(), cert, tw)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get identity key of signer")
+	})
+
+	t.Run("returns error when CreateSignature fails", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t)
+		tw.OnCreateSignature().ReturnError(errors.New("sign boom"))
+
+		_, err := utils.SignCertificateWithWalletForTest(context.Background(), cert, tw)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to sign certificate")
+	})
+}
+
+// TestGetVerifiableCertificatesErrorPaths covers the remaining error/skip branches.
+func TestGetVerifiableCertificatesErrorPaths(t *testing.T) {
+	ctx := context.Background()
+
+	verifierKey := tu.GetPKFromString("verifier")
+	certType1 := tu.GetByte32FromString("certType1")
+	certType2 := tu.GetByte32FromString("certType2")
+	serial1 := tu.GetByte32FromString("serial1")
+
+	const testSigHex = "3045022100a6f09ee70382ab364f3f6b040aebb8fe7a51dbc3b4c99cfeb2f7756432162833022067349b91a6319345996faddf36d1b2f3a502e4ae002205f9d2db85474f9aed5a"
+	testSig := tu.GetSigFromHex(t, testSigHex)
+
+	subject := tu.GetPKFromString("subject")
+	certifier := tu.GetPKFromString("certifier")
+
+	requestedCerts := &utils.RequestedCertificateSet{
+		Certifiers: []*ec.PublicKey{tu.GetPKFromString("certifier1")},
+		CertificateTypes: utils.RequestedCertificateTypeIDAndFieldList{
+			certType1: {"field1"},
+		},
+	}
+
+	newMatchingCert := func() wallet.CertificateResult {
+		return wallet.CertificateResult{
+			Certificate: wallet.Certificate{
+				Type:               certType1,
+				SerialNumber:       serial1,
+				Subject:            subject,
+				Certifier:          certifier,
+				RevocationOutpoint: tu.OutpointFromString(t, "a755810c21e17183ff6db6685f0de239fd3a0a3c0d4ba7773b0b0d1748541e2b.0"),
+				Fields:             map[string]string{"field1": base64.StdEncoding.EncodeToString([]byte("v"))},
+				Signature:          testSig,
+			},
+		}
+	}
+
+	t.Run("returns error for nil options", func(t *testing.T) {
+		certs, err := utils.GetVerifiableCertificates(ctx, nil)
+		require.Error(t, err)
+		assert.Nil(t, certs)
+		require.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("returns error for nil wallet", func(t *testing.T) {
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                nil,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.Error(t, err)
+		assert.Nil(t, certs)
+		require.Contains(t, err.Error(), "options.Wallet cannot be nil")
+	})
+
+	t.Run("returns error for nil ListCertificates result", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(nil)
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.Error(t, err)
+		assert.Nil(t, certs)
+		require.Contains(t, err.Error(), "nil result from ListCertificates")
+	})
+
+	t.Run("skips certificate with empty type", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(&wallet.ListCertificatesResult{
+			Certificates: []wallet.CertificateResult{{Certificate: wallet.Certificate{}}},
+		})
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, certs)
+	})
+
+	t.Run("skips certificate whose type was not requested", func(t *testing.T) {
+		notRequested := newMatchingCert()
+		notRequested.Type = certType2
+
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(&wallet.ListCertificatesResult{
+			Certificates: []wallet.CertificateResult{notRequested},
+		})
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, certs)
+	})
+
+	t.Run("propagates ProveCertificate error", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(&wallet.ListCertificatesResult{
+			Certificates: []wallet.CertificateResult{newMatchingCert()},
+		})
+		tw.OnProveCertificate().ReturnError(errors.New("prove boom"))
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.Error(t, err)
+		assert.Nil(t, certs)
+		require.Contains(t, err.Error(), "prove boom")
+	})
+
+	t.Run("returns error for nil ProveCertificate result", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(&wallet.ListCertificatesResult{
+			Certificates: []wallet.CertificateResult{newMatchingCert()},
+		})
+		tw.OnProveCertificate().ReturnSuccess(nil)
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.Error(t, err)
+		assert.Nil(t, certs)
+		require.Contains(t, err.Error(), "nil result from ProveCertificate")
+	})
+
+	t.Run("returns error for keyring value that is not base64", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(&wallet.ListCertificatesResult{
+			Certificates: []wallet.CertificateResult{newMatchingCert()},
+		})
+		tw.OnProveCertificate().ReturnSuccess(&wallet.ProveCertificateResult{
+			KeyringForVerifier: map[string]string{"field1": "not valid base64!!!"},
+		})
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.Error(t, err)
+		assert.Nil(t, certs)
+		require.Contains(t, err.Error(), "is not valid base64")
+	})
+
+	t.Run("builds verifiable certificate with valid keyring", func(t *testing.T) {
+		tw := wallet.NewTestWalletForRandomKey(t) //nolint:contextcheck // shared test helper uses context.Background() internally
+		tw.OnListCertificates().ReturnSuccess(&wallet.ListCertificatesResult{
+			Certificates: []wallet.CertificateResult{newMatchingCert()},
+		})
+		tw.OnProveCertificate().ReturnSuccess(&wallet.ProveCertificateResult{
+			KeyringForVerifier: map[string]string{"field1": base64.StdEncoding.EncodeToString([]byte("key"))},
+		})
+
+		certs, err := utils.GetVerifiableCertificates(ctx, &utils.GetVerifiableCertificatesOptions{
+			Wallet:                tw,
+			RequestedCertificates: requestedCerts,
+			VerifierIdentityKey:   verifierKey,
+		})
+		require.NoError(t, err)
+		require.Len(t, certs, 1)
+		assert.Equal(t, wallet.StringBase64FromArray(certType1), certs[0].Type)
+	})
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,10 +31,22 @@ ignore:
   - ".mage-cache/**"
   - ".vscode/**"
   - "bin/**"
+  - "docs/**" # example programs — no tests, always 0% (matches Sonar coverage exclusion)
   - "example/**"
   - "examples/**"
   - "mocks/**"
   - "testing/**"
+  # Test infrastructure & fixtures. These live in non-_test.go files so the helpers can be
+  # shared across packages' tests (e.g. wallet.NewTestWalletForRandomKey, registry.MockRegistry),
+  # which is why go/codecov instrument them. Sonar already excludes all of these via its
+  # `**test**` glob (sonar-project.properties); this mirrors that policy for Codecov.
+  - "**/testdata/**"
+  - "**/test_util/**"
+  - "**/test_cert_util/**"
+  - "**/testcertificates/**"
+  - "**/test_wallet.go"
+  - "**/test_logger.go"
+  - "**/mock.go"
 
 # Parsers
 # --------------

--- a/compat/bip32/derive_extra_test.go
+++ b/compat/bip32/derive_extra_test.go
@@ -1,0 +1,70 @@
+package compat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	compat "github.com/bsv-blockchain/go-sdk/compat/bip32"
+)
+
+// TestDeriveNumberParseErrors covers the ParseUint failure branches of DeriveNumber
+// for the second and third path segments.
+func TestDeriveNumberParseErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "second segment not numeric", path: "2147483648/notanumber/2147483648"},
+		{name: "third segment not numeric", path: "2147483648/2147483648/notanumber"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := compat.DeriveNumber(tc.path)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestDeriveChildFromPathChildIntOverflow covers the childInt ParseUint failure branch
+// (and the wrapping error in DeriveChildFromPath) when a path segment matches the
+// numeric-plus-tick pattern but overflows a uint32.
+func TestDeriveChildFromPathChildIntOverflow(t *testing.T) {
+	t.Parallel()
+
+	k, err := compat.NewKeyFromString(testXPriv)
+	require.NoError(t, err)
+
+	_, err = k.DeriveChildFromPath("99999999999999999999")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "derive key failed")
+}
+
+// TestDeriveChildFromPathChildError covers the branch where Child fails while walking
+// the path: deriving a hardened child from a public extended key.
+func TestDeriveChildFromPathChildError(t *testing.T) {
+	t.Parallel()
+
+	k, err := compat.NewKeyFromString(testXPriv)
+	require.NoError(t, err)
+	pub, err := k.Neuter()
+	require.NoError(t, err)
+
+	_, err = pub.DeriveChildFromPath("0'")
+	require.ErrorIs(t, err, compat.ErrDeriveHardFromPublic)
+}
+
+// TestDerivePublicKeyFromPathError covers the error branch of DerivePublicKeyFromPath
+// when the derivation path itself is invalid.
+func TestDerivePublicKeyFromPathError(t *testing.T) {
+	t.Parallel()
+
+	k, err := compat.NewKeyFromString(testXPriv)
+	require.NoError(t, err)
+
+	_, err = k.DerivePublicKeyFromPath("not-a-valid-path")
+	require.Error(t, err)
+}

--- a/compat/bip32/extendedkey_extra_test.go
+++ b/compat/bip32/extendedkey_extra_test.go
@@ -1,0 +1,122 @@
+package compat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	base58 "github.com/bsv-blockchain/go-sdk/compat/base58"
+	compat "github.com/bsv-blockchain/go-sdk/compat/bip32"
+	hash "github.com/bsv-blockchain/go-sdk/primitives/hash"
+	chaincfg "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
+)
+
+// buildSerializedExtendedKey hand-builds a base58-encoded extended key with a valid
+// checksum from the given version and 33-byte key data, so NewKeyFromString error
+// branches past the length/checksum checks can be exercised.
+func buildSerializedExtendedKey(t *testing.T, version, keyData []byte) string {
+	t.Helper()
+	require.Len(t, keyData, 33)
+
+	payload := make([]byte, 0, 78)
+	payload = append(payload, version...)             // 4 bytes version
+	payload = append(payload, 0x00)                   // 1 byte depth
+	payload = append(payload, 0x00, 0x00, 0x00, 0x00) // 4 bytes parent fingerprint
+	payload = append(payload, 0x00, 0x00, 0x00, 0x00) // 4 bytes child number
+	payload = append(payload, make([]byte, 32)...)    // 32 bytes chain code
+	payload = append(payload, keyData...)             // 33 bytes key data
+
+	checkSum := hash.Sha256d(payload)[:4]
+	payload = append(payload, checkSum...)
+	return base58.Encode(payload)
+}
+
+// TestChildBeyondMaxDepth covers the max-depth guard in Child.
+func TestChildBeyondMaxDepth(t *testing.T) {
+	t.Parallel()
+
+	version := chaincfg.MainNet.HDPrivateKeyID[:]
+	k := compat.NewExtendedKey(version, make([]byte, 32), make([]byte, 32), []byte{0, 0, 0, 0}, 255, 0, true)
+
+	_, err := k.Child(0)
+	require.ErrorIs(t, err, compat.ErrDeriveBeyondMaxDepth)
+}
+
+// TestChildPublicNonHardened covers deriving a non-hardened child from a public
+// extended key (the point-addition branch of Child).
+func TestChildPublicNonHardened(t *testing.T) {
+	t.Parallel()
+
+	k, err := compat.NewKeyFromString(testXPriv)
+	require.NoError(t, err)
+	pub, err := k.Neuter()
+	require.NoError(t, err)
+
+	child, err := pub.Child(0)
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	require.False(t, child.IsPrivate())
+}
+
+// TestNeuterInvalidVersion covers the branch where Neuter fails to map an unknown
+// private version to its public counterpart.
+func TestNeuterInvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	k := compat.NewExtendedKey([]byte{0x01, 0x02, 0x03, 0x04}, make([]byte, 32), make([]byte, 32), []byte{0, 0, 0, 0}, 0, 0, true)
+	_, err := k.Neuter()
+	require.Error(t, err)
+}
+
+// TestStringPaddedKey covers the leading-zero padding branch of paddedAppend when a
+// private key is shorter than 32 bytes.
+func TestStringPaddedKey(t *testing.T) {
+	t.Parallel()
+
+	version := chaincfg.MainNet.HDPrivateKeyID[:]
+	shortKey := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	k := compat.NewExtendedKey(version, shortKey, make([]byte, 32), []byte{0, 0, 0, 0}, 0, 0, true)
+
+	s := k.String()
+	require.NotEmpty(t, s)
+	require.NotEqual(t, "zeroed extended key", s)
+}
+
+// TestNewKeyFromStringBadChecksum covers the checksum-mismatch branch of NewKeyFromString
+// while keeping the serialized length valid.
+func TestNewKeyFromStringBadChecksum(t *testing.T) {
+	t.Parallel()
+
+	decoded, err := base58.Decode(testXPriv)
+	require.NoError(t, err)
+	// Corrupt the final checksum byte without changing the length.
+	decoded[len(decoded)-1] ^= 0xff
+	_, err = compat.NewKeyFromString(base58.Encode(decoded))
+	require.ErrorIs(t, err, compat.ErrBadChecksum)
+}
+
+// TestNewKeyFromStringUnusablePrivateKey covers the branch where the serialized private
+// key data is out of range (all zeros).
+func TestNewKeyFromStringUnusablePrivateKey(t *testing.T) {
+	t.Parallel()
+
+	keyData := make([]byte, 33) // leading 0x00 marks private, remaining 32 bytes all zero
+	encoded := buildSerializedExtendedKey(t, chaincfg.MainNet.HDPrivateKeyID[:], keyData)
+	_, err := compat.NewKeyFromString(encoded)
+	require.ErrorIs(t, err, compat.ErrUnusableSeed)
+}
+
+// TestNewKeyFromStringInvalidPublicKey covers the branch where the serialized public key
+// data does not parse as a valid point.
+func TestNewKeyFromStringInvalidPublicKey(t *testing.T) {
+	t.Parallel()
+
+	keyData := make([]byte, 33)
+	keyData[0] = 0x01 // invalid pubkey format byte (and not the 0x00 private marker)
+	for i := 1; i < 33; i++ {
+		keyData[i] = 0xff
+	}
+	encoded := buildSerializedExtendedKey(t, chaincfg.MainNet.HDPublicKeyID[:], keyData)
+	_, err := compat.NewKeyFromString(encoded)
+	require.Error(t, err)
+}

--- a/compat/bip32/hd_key_extra_test.go
+++ b/compat/bip32/hd_key_extra_test.go
@@ -1,0 +1,19 @@
+package compat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	compat "github.com/bsv-blockchain/go-sdk/compat/bip32"
+)
+
+// TestGetExtendedPublicKeyNeuterError covers the error branch of GetExtendedPublicKey
+// when the underlying key has an unmappable (invalid) private version and Neuter fails.
+func TestGetExtendedPublicKeyNeuterError(t *testing.T) {
+	t.Parallel()
+
+	k := compat.NewExtendedKey([]byte{0x01, 0x02, 0x03, 0x04}, make([]byte, 32), make([]byte, 32), []byte{0, 0, 0, 0}, 0, 0, true)
+	_, err := compat.GetExtendedPublicKey(k)
+	require.Error(t, err)
+}

--- a/compat/bsm/verify_extra_test.go
+++ b/compat/bsm/verify_extra_test.go
@@ -1,0 +1,32 @@
+package compat_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	compat "github.com/bsv-blockchain/go-sdk/compat/bsm"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+)
+
+// TestVerifyMessageDERInvalidPublicKey covers the branch where the signature is valid
+// DER but the supplied public key hex does not parse as a valid point.
+func TestVerifyMessageDERInvalidPublicKey(t *testing.T) {
+	t.Parallel()
+
+	// Produce a valid strict-DER signature over an arbitrary hash.
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	var hash [32]byte
+	sig, err := pk.Sign(hash[:])
+	require.NoError(t, err)
+	sigHex := hex.EncodeToString(sig.Serialize())
+
+	// A well-formed hex string that is not a valid compressed public key point.
+	badPubKey := "02" + "ff00000000000000000000000000000000000000000000000000000000000000"
+
+	verified, err := compat.VerifyMessageDER(hash, badPubKey, sigHex)
+	require.Error(t, err)
+	require.False(t, verified)
+}

--- a/compat/ecies/ecies_extra_test.go
+++ b/compat/ecies/ecies_extra_test.go
@@ -1,0 +1,108 @@
+package compat
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+)
+
+// TestDecryptSharedBase64Error covers the base64-decode failure branch of DecryptShared.
+func TestDecryptSharedBase64Error(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	_, err = DecryptShared("!!!not-valid-base64!!!", priv, priv.PubKey())
+	require.Error(t, err)
+}
+
+// TestDecryptSharedElectrumError covers the branch where DecryptShared decodes valid
+// base64 but ElectrumDecrypt rejects the (too short) payload.
+func TestDecryptSharedElectrumError(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	short := base64.StdEncoding.EncodeToString(make([]byte, 10))
+	_, err = DecryptShared(short, priv, priv.PubKey())
+	require.Error(t, err)
+}
+
+// TestElectrumDecryptErrors covers the guarded failure branches of ElectrumDecrypt.
+func TestElectrumDecryptErrors(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	validPub := priv.PubKey().Compressed()
+
+	t.Run("too short", func(t *testing.T) {
+		t.Parallel()
+		_, err := ElectrumDecrypt(make([]byte, 10), priv, nil)
+		require.ErrorContains(t, err, "length")
+	})
+
+	t.Run("invalid magic bytes", func(t *testing.T) {
+		t.Parallel()
+		data := make([]byte, 60) // long enough, but no BIE1 prefix
+		_, err := ElectrumDecrypt(data, priv, nil)
+		require.ErrorContains(t, err, "magic")
+	})
+
+	t.Run("invalid ephemeral public key", func(t *testing.T) {
+		t.Parallel()
+		data := make([]byte, 52)
+		copy(data, "BIE1")
+		for i := 4; i < 37; i++ {
+			data[i] = 0xff // not a valid curve point
+		}
+		_, err := ElectrumDecrypt(data, priv, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("mac mismatch", func(t *testing.T) {
+		t.Parallel()
+		// BIE1 + valid ephemeral pubkey (33) + cipher (16) + wrong mac (32).
+		data := append([]byte("BIE1"), validPub...)
+		data = append(data, make([]byte, 16)...) // cipher text placeholder
+		data = append(data, make([]byte, 32)...) // incorrect mac
+		_, err := ElectrumDecrypt(data, priv, nil)
+		require.ErrorContains(t, err, "incorrect password")
+	})
+}
+
+// TestBitcoreDecryptErrors covers the guarded failure branches of BitcoreDecrypt.
+func TestBitcoreDecryptErrors(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	other, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	t.Run("invalid sender public key", func(t *testing.T) {
+		t.Parallel()
+		data := make([]byte, 85)
+		for i := 0; i < 33; i++ {
+			data[i] = 0xff // not a valid curve point
+		}
+		_, err := BitcoreDecrypt(data, priv)
+		require.Error(t, err)
+	})
+
+	t.Run("hmac mismatch", func(t *testing.T) {
+		t.Parallel()
+		// valid sender pubkey (33) + cipher (20) + wrong mac (32).
+		data := append([]byte{}, other.PubKey().ToDER()...)
+		data = append(data, make([]byte, 20)...) // cipher text placeholder
+		data = append(data, make([]byte, 32)...) // incorrect mac
+		_, err := BitcoreDecrypt(data, priv)
+		require.ErrorContains(t, err, "HMAC mismatch")
+	})
+}

--- a/identity/client_paths_extra_test.go
+++ b/identity/client_paths_extra_test.go
@@ -1,0 +1,144 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/script"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-sdk/wallet/testcertificates"
+)
+
+// issueRealCert creates a subject wallet and issues a real, verifiable
+// certificate so PubliclyRevealAttributes gets past certificate verification.
+func issueRealCert(t *testing.T) (*wallet.TestWallet, *wallet.Certificate, []CertificateFieldNameUnder50Bytes) {
+	t.Helper()
+	subjectPrivKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	subjectWallet := wallet.NewTestWallet(t, subjectPrivKey)
+
+	certMgr := testcertificates.NewManager(t, subjectWallet)
+	issued := certMgr.CertificateForTest().
+		WithType("identity-broadcast-cert").
+		WithFieldValue("userName", "Alice").
+		Issue()
+	require.NotNil(t, issued.WalletCert)
+
+	return subjectWallet, issued.WalletCert, []CertificateFieldNameUnder50Bytes{"userName"}
+}
+
+// TestPubliclyRevealAttributesReachesBroadcast drives the real client all the
+// way through transaction creation, network detection, and broadcast. The
+// broadcast itself fails because outbound HTTP is disabled, exercising the
+// mainnet/testnet broadcaster branches and the Broadcast call.
+func TestPubliclyRevealAttributesReachesBroadcast(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+	}{
+		{"testnet", "testnet"},
+		{"mainnet", "mainnet"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tu.WithUnreachableTransport(t)
+			subjectWallet, cert, fields := issueRealCert(t)
+			subjectWallet.OnCreateAction().ReturnSuccess(&wallet.CreateActionResult{
+				Tx: tu.SingleOutputBeef(t, &script.Script{}),
+			})
+			subjectWallet.OnGetNetwork().ReturnSuccess(&wallet.GetNetworkResult{Network: wallet.Network(tc.network)})
+
+			client, err := NewClient(subjectWallet, nil, "")
+			require.NoError(t, err)
+
+			success, failure, err := client.PubliclyRevealAttributes(context.Background(), cert, fields)
+			require.NoError(t, err)
+			require.Nil(t, success)
+			require.NotNil(t, failure)
+		})
+	}
+}
+
+// TestPubliclyRevealAttributesSimpleBroadcastFailure covers the Simple wrapper's
+// broadcast-failure return branch.
+func TestPubliclyRevealAttributesSimpleBroadcastFailure(t *testing.T) {
+	tu.WithUnreachableTransport(t)
+	subjectWallet, cert, fields := issueRealCert(t)
+	subjectWallet.OnCreateAction().ReturnSuccess(&wallet.CreateActionResult{
+		Tx: tu.SingleOutputBeef(t, &script.Script{}),
+	})
+	subjectWallet.OnGetNetwork().ReturnSuccess(&wallet.GetNetworkResult{Network: "testnet"})
+
+	client, err := NewClient(subjectWallet, nil, "")
+	require.NoError(t, err)
+
+	txid, err := client.PubliclyRevealAttributesSimple(context.Background(), cert, fields)
+	require.Error(t, err)
+	require.Empty(t, txid)
+	require.Contains(t, err.Error(), "broadcast failed")
+}
+
+// TestPubliclyRevealAttributesNilTx covers the branch where CreateAction returns
+// a result without a transaction.
+func TestPubliclyRevealAttributesNilTx(t *testing.T) {
+	subjectWallet, cert, fields := issueRealCert(t)
+	subjectWallet.OnCreateAction().ReturnSuccess(&wallet.CreateActionResult{Tx: nil})
+
+	client, err := NewClient(subjectWallet, nil, "")
+	require.NoError(t, err)
+
+	_, _, err = client.PubliclyRevealAttributes(context.Background(), cert, fields)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "public reveal failed")
+}
+
+// TestPubliclyRevealAttributesInvalidBEEF covers the branch where the created
+// transaction bytes cannot be parsed as BEEF.
+func TestPubliclyRevealAttributesInvalidBEEF(t *testing.T) {
+	subjectWallet, cert, fields := issueRealCert(t)
+	subjectWallet.OnCreateAction().ReturnSuccess(&wallet.CreateActionResult{Tx: []byte("invalid-beef")})
+
+	client, err := NewClient(subjectWallet, nil, "")
+	require.NoError(t, err)
+
+	_, _, err = client.PubliclyRevealAttributes(context.Background(), cert, fields)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to create transaction from BEEF")
+}
+
+// TestPubliclyRevealAttributesGetNetworkError covers the branch where network
+// detection fails after a transaction is created.
+func TestPubliclyRevealAttributesGetNetworkError(t *testing.T) {
+	subjectWallet, cert, fields := issueRealCert(t)
+	subjectWallet.OnCreateAction().ReturnSuccess(&wallet.CreateActionResult{
+		Tx: tu.SingleOutputBeef(t, &script.Script{}),
+	})
+	subjectWallet.OnGetNetwork().ReturnError(fmt.Errorf("network unavailable"))
+
+	client, err := NewClient(subjectWallet, nil, "")
+	require.NoError(t, err)
+
+	_, _, err = client.PubliclyRevealAttributes(context.Background(), cert, fields)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get network")
+}
+
+// TestPubliclyRevealAttributesVerifyFailure covers the branch where a tampered
+// certificate fails verification.
+func TestPubliclyRevealAttributesVerifyFailure(t *testing.T) {
+	subjectWallet, cert, fields := issueRealCert(t)
+	// Replace the valid signature with an unrelated one so verification fails.
+	cert.Signature = &ec.Signature{R: big.NewInt(2), S: big.NewInt(3)}
+
+	client, err := NewClient(subjectWallet, nil, "")
+	require.NoError(t, err)
+
+	_, _, err = client.PubliclyRevealAttributes(context.Background(), cert, fields)
+	require.Error(t, err)
+}

--- a/identity/testable_client_paths_extra_test.go
+++ b/identity/testable_client_paths_extra_test.go
@@ -1,0 +1,81 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// newTestableClientForPaths builds a TestableIdentityClient backed by a mockable
+// wallet and a permissive certificate verifier, plus a minimal certificate.
+func newTestableClientForPaths(t *testing.T, keyInt int) (*TestableIdentityClient, *wallet.TestWallet, *wallet.Certificate) {
+	t.Helper()
+	privKey, pubKey := privateKeyFromInt(keyInt)
+	mockWallet := wallet.NewTestWallet(t, privKey)
+	client, err := NewTestableIdentityClient(mockWallet, nil, "", &MockCertificateVerifier{})
+	require.NoError(t, err)
+	cert := &wallet.Certificate{
+		Subject: pubKey,
+		Fields:  map[string]string{"name": "Alice"},
+	}
+	return client, mockWallet, cert
+}
+
+func TestTestablePubliclyRevealAttributesValidation(t *testing.T) {
+	t.Run("no fields on certificate", func(t *testing.T) {
+		client, _, _ := newTestableClientForPaths(t, 310)
+		cert := &wallet.Certificate{Fields: map[string]string{}}
+		_, _, err := client.PubliclyRevealAttributes(context.Background(), cert, []CertificateFieldNameUnder50Bytes{"name"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no fields to reveal")
+	})
+
+	t.Run("no fields requested", func(t *testing.T) {
+		client, _, cert := newTestableClientForPaths(t, 311)
+		_, _, err := client.PubliclyRevealAttributes(context.Background(), cert, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one field")
+	})
+}
+
+func TestTestablePubliclyRevealAttributesProveCertificateError(t *testing.T) {
+	client, mockWallet, cert := newTestableClientForPaths(t, 312)
+	mockWallet.OnProveCertificate().ReturnError(fmt.Errorf("prove failed"))
+
+	_, _, err := client.PubliclyRevealAttributes(context.Background(), cert, []CertificateFieldNameUnder50Bytes{"name"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to prove certificate")
+}
+
+func TestTestablePubliclyRevealAttributesLockError(t *testing.T) {
+	client, mockWallet, cert := newTestableClientForPaths(t, 313)
+	mockWallet.OnProveCertificate().ReturnSuccess(&wallet.ProveCertificateResult{
+		KeyringForVerifier: map[string]string{"k": "v"},
+	})
+	mockWallet.OnCreateSignature().ReturnError(fmt.Errorf("cannot sign"))
+
+	_, _, err := client.PubliclyRevealAttributes(context.Background(), cert, []CertificateFieldNameUnder50Bytes{"name"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to create locking script")
+}
+
+func TestTestablePubliclyRevealAttributesCreateActionError(t *testing.T) {
+	client, mockWallet, cert := newTestableClientForPaths(t, 314)
+	mockWallet.OnProveCertificate().ReturnSuccess(&wallet.ProveCertificateResult{
+		KeyringForVerifier: map[string]string{"k": "v"},
+	})
+	mockWallet.OnCreateSignature().ReturnSuccess(&wallet.CreateSignatureResult{
+		Signature: &ec.Signature{R: big.NewInt(1), S: big.NewInt(1)},
+	})
+	mockWallet.OnCreateAction().ReturnError(fmt.Errorf("cannot create action"))
+
+	_, _, err := client.PubliclyRevealAttributes(context.Background(), cert, []CertificateFieldNameUnder50Bytes{"name"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to create action")
+}

--- a/kvstore/kvstore_paths_extra_test.go
+++ b/kvstore/kvstore_paths_extra_test.go
@@ -1,0 +1,144 @@
+package kvstore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/kvstore"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// TestLocalKVStoreGetEncryptedDecryptSuccess covers the successful-decrypt branch
+// of lookupValue (local_kv_store.go:156), where an encrypted store decrypts the
+// stored PushDrop field to obtain the plaintext value.
+func TestLocalKVStoreGetEncryptedDecryptSuccess(t *testing.T) {
+	t.Parallel()
+
+	mockWallet := wallet.NewTestWalletForRandomKey(t)
+	mockWallet.OnListOutputs().ReturnSuccess(&wallet.ListOutputsResult{
+		Outputs: []wallet.Output{
+			{Satoshis: 1, Outpoint: buildOutpoint(t, pushDropTxID, 0)},
+		},
+		BEEF: decodePushDropBeef(t),
+	})
+	mockWallet.OnDecrypt().ReturnSuccess(&wallet.DecryptResult{
+		Plaintext: []byte("secret-value"),
+	})
+
+	store, err := kvstore.NewLocalKVStore(kvstore.KVStoreConfig{
+		Wallet:  mockWallet,
+		Context: "test-context",
+		Encrypt: true,
+	})
+	require.NoError(t, err)
+
+	value, err := store.Get(context.Background(), "mykey", "default")
+	require.NoError(t, err)
+	require.Equal(t, "secret-value", value)
+}
+
+// TestLocalKVStoreGetEncryptedDecryptError covers the decrypt-failure branch of
+// lookupValue (local_kv_store.go:151-154).
+func TestLocalKVStoreGetEncryptedDecryptError(t *testing.T) {
+	t.Parallel()
+
+	mockWallet := wallet.NewTestWalletForRandomKey(t)
+	mockWallet.OnListOutputs().ReturnSuccess(&wallet.ListOutputsResult{
+		Outputs: []wallet.Output{
+			{Satoshis: 1, Outpoint: buildOutpoint(t, pushDropTxID, 0)},
+		},
+		BEEF: decodePushDropBeef(t),
+	})
+	mockWallet.OnDecrypt().ReturnError(errors.New("decrypt boom"))
+
+	store, err := kvstore.NewLocalKVStore(kvstore.KVStoreConfig{
+		Wallet:  mockWallet,
+		Context: "test-context",
+		Encrypt: true,
+	})
+	require.NoError(t, err)
+
+	_, err = store.Get(context.Background(), "mykey", "default")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "decrypt boom")
+}
+
+// TestLocalKVStoreSetLockError covers the PushDrop.Lock failure branch of Set
+// (local_kv_store.go:281-282). With no existing outputs, Set proceeds to build a
+// new locking script; a failing GetPublicKey makes PushDrop.Lock error.
+func TestLocalKVStoreSetLockError(t *testing.T) {
+	t.Parallel()
+
+	mockWallet := wallet.NewTestWalletForRandomKey(t)
+	mockWallet.OnListOutputs().ReturnSuccess(&wallet.ListOutputsResult{
+		Outputs: []wallet.Output{},
+	})
+	mockWallet.OnGetPublicKey().ReturnError(errors.New("no pubkey available"))
+
+	store, err := kvstore.NewLocalKVStore(kvstore.KVStoreConfig{
+		Wallet:  mockWallet,
+		Context: "test-context",
+		Encrypt: false,
+	})
+	require.NoError(t, err)
+
+	_, err = store.Set(context.Background(), "mykey", "myvalue")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "locking script")
+}
+
+// TestLocalKVStoreSetEncryptError covers the encrypt-failure branch of Set
+// (local_kv_store.go:259-261) for an encrypted store.
+func TestLocalKVStoreSetEncryptError(t *testing.T) {
+	t.Parallel()
+
+	mockWallet := wallet.NewTestWalletForRandomKey(t)
+	mockWallet.OnListOutputs().ReturnSuccess(&wallet.ListOutputsResult{
+		Outputs: []wallet.Output{},
+	})
+	mockWallet.OnEncrypt().ReturnError(errors.New("encrypt boom"))
+
+	store, err := kvstore.NewLocalKVStore(kvstore.KVStoreConfig{
+		Wallet:  mockWallet,
+		Context: "test-context",
+		Encrypt: true,
+	})
+	require.NoError(t, err)
+
+	_, err = store.Set(context.Background(), "mykey", "myvalue")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "encrypt boom")
+}
+
+// TestLocalKVStoreSetPrepareSpendsSourceNotLinked covers the source-transaction
+// linking guard in prepareSpends (local_kv_store.go:405-406). The signable tx is
+// found within the input BEEF, but its input has no linked source transaction.
+func TestLocalKVStoreSetPrepareSpendsSourceNotLinked(t *testing.T) {
+	t.Parallel()
+
+	store, mockWallet := setupTestKVStore(t)
+	returnPushDropOutput(t, mockWallet)
+
+	// Use the PushDrop transaction itself (present in the input BEEF) as the
+	// signable transaction so FindTransactionForSigning locates it, then the
+	// unlinked source transaction trips the linking guard.
+	beefData, _, err := transaction.NewBeefFromAtomicBytes(decodePushDropBeef(t))
+	require.NoError(t, err)
+	pushTx := beefData.FindTransaction(pushDropTxID)
+	require.NotNil(t, pushTx)
+
+	mockWallet.OnCreateAction().ReturnSuccess(&wallet.CreateActionResult{
+		SignableTransaction: &wallet.SignableTransaction{
+			Tx:        pushTx.Bytes(),
+			Reference: []byte("ref"),
+		},
+	})
+
+	_, err = store.Set(context.Background(), "mykey", "differentvalue")
+	require.Error(t, err)
+	require.ErrorContains(t, err, errPrepareSpends)
+}

--- a/message/signed_extra_test.go
+++ b/message/signed_extra_test.go
@@ -1,0 +1,44 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+)
+
+// TestVerifyInvalidSignerPublicKey covers the branch where the embedded signer
+// public key bytes do not parse as a valid point.
+func TestVerifyInvalidSignerPublicKey(t *testing.T) {
+	t.Parallel()
+	recipient, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// VERSION_BYTES followed by 33 zero bytes (an invalid compressed key).
+	sig := append([]byte{}, VERSION_BYTES...)
+	sig = append(sig, make([]byte, 33)...)
+
+	_, err = Verify([]byte("msg"), sig, recipient)
+	require.Error(t, err)
+}
+
+// TestVerifyInvalidSignatureDER covers the branch where the trailing signature
+// bytes are not valid DER.
+func TestVerifyInvalidSignatureDER(t *testing.T) {
+	t.Parallel()
+	signer, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	recipient, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// version + valid signer pubkey + verifierFirst==0 (anyone) + keyID + bad DER
+	sig := append([]byte{}, VERSION_BYTES...)
+	sig = append(sig, signer.PubKey().Compressed()...)
+	sig = append(sig, 0x00)                  // verifierFirst == 0 -> "anyone" path
+	sig = append(sig, make([]byte, 32)...)   // keyID
+	sig = append(sig, []byte{0x00, 0x01}...) // invalid DER signature
+
+	_, err = Verify([]byte("msg"), sig, recipient)
+	require.Error(t, err)
+}

--- a/overlay/admin-token/admin_token_paths_extra_test.go
+++ b/overlay/admin-token/admin_token_paths_extra_test.go
@@ -1,0 +1,56 @@
+package admintoken_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/overlay"
+	admintoken "github.com/bsv-blockchain/go-sdk/overlay/admin-token"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/pushdrop"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// TestDecodeTooFewFields covers the branch where a pushdrop script decodes but
+// has fewer than the four fields an admin token requires.
+func TestDecodeTooFewFields(t *testing.T) {
+	testWallet := createTestWallet(t)
+	pushDrop := &pushdrop.PushDrop{
+		Wallet:     testWallet,
+		Originator: testOriginator,
+	}
+	ctx := context.Background()
+
+	protocolID := wallet.Protocol{SecurityLevel: 2, Protocol: "service host interconnect"}
+	lockingScript, err := pushDrop.Lock(
+		ctx,
+		[][]byte{
+			[]byte(overlay.ProtocolSHIP),
+			[]byte("only-two-fields"),
+		},
+		protocolID,
+		"1",
+		wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+		false,
+		true,
+		pushdrop.LockBefore,
+	)
+	require.NoError(t, err)
+
+	assert.Nil(t, admintoken.Decode(lockingScript))
+}
+
+// TestLockGetPublicKeyError covers the branch where fetching the identity key
+// fails before the token is locked.
+func TestLockGetPublicKeyError(t *testing.T) {
+	mockWallet := wallet.NewTestWalletForRandomKey(t)
+	mockWallet.OnGetPublicKey().ReturnError(errors.New("no identity key"))
+
+	template := admintoken.NewOverlayAdminToken(mockWallet, testOriginator)
+	_, err := template.Lock(context.Background(), overlay.ProtocolSHIP, "example.com", "tm_tests")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no identity key")
+}

--- a/overlay/lookup/facilitator_paths_extra_test.go
+++ b/overlay/lookup/facilitator_paths_extra_test.go
@@ -1,0 +1,73 @@
+package lookup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+)
+
+// TestParseBinaryLookupAnswerErrors covers the truncated-input error branches of
+// the binary output-list decoder.
+func TestParseBinaryLookupAnswerErrors(t *testing.T) {
+	t.Parallel()
+
+	txid := make([]byte, 32)
+
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{
+			name:    "empty data fails reading outpoint count",
+			data:    []byte{},
+			wantErr: "reading outpoint count",
+		},
+		{
+			name:    "truncated after txid fails reading output index",
+			data:    append([]byte{0x01}, txid...),
+			wantErr: "reading outputIndex",
+		},
+		{
+			name:    "truncated after output index fails reading context length",
+			data:    append(append([]byte{0x01}, txid...), 0x00),
+			wantErr: "reading contextLen",
+		},
+		{
+			name:    "truncated context fails reading context",
+			data:    append(append([]byte{0x01}, txid...), 0x00, 0x05),
+			wantErr: "reading context",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseBinaryLookupAnswer(tc.data)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestParseBinaryLookupAnswerTxidNotInBeef covers the branch where a referenced
+// txid is not present in the trailing shared BEEF.
+func TestParseBinaryLookupAnswerTxidNotInBeef(t *testing.T) {
+	t.Parallel()
+	beef := tu.SingleOutputBeef(t, &script.Script{})
+
+	// One outpoint referencing an all-zero txid (not present in the BEEF),
+	// output index 0, no context, followed by the shared BEEF.
+	data := make([]byte, 0, 1+32+2+len(beef))
+	data = append(data, 0x01)
+	data = append(data, make([]byte, 32)...)
+	data = append(data, 0x00, 0x00)
+	data = append(data, beef...)
+
+	_, err := parseBinaryLookupAnswer(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found in BEEF")
+}

--- a/overlay/lookup/resolver_paths_extra_test.go
+++ b/overlay/lookup/resolver_paths_extra_test.go
@@ -1,0 +1,156 @@
+package lookup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/overlay"
+	"github.com/bsv-blockchain/go-sdk/script"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+)
+
+// TestNewLookupResolverTestnetDefaultTrackers covers the branch that defaults
+// SLAP trackers to the testnet list when the preset is not mainnet.
+func TestNewLookupResolverTestnetDefaultTrackers(t *testing.T) {
+	t.Parallel()
+	r := NewLookupResolver(&LookupResolver{NetworkPreset: overlay.NetworkTestnet})
+	require.Equal(t, DEFAULT_TESTNET_SLAP_TRACKERS, r.SLAPTrackers)
+}
+
+// TestQueryLocalNetworkUsesLocalhost covers the local-network host selection.
+func TestQueryLocalNetworkUsesLocalhost(t *testing.T) {
+	t.Parallel()
+	r := &LookupResolver{
+		Facilitator:     &mockFacilitator{answer: &LookupAnswer{Type: AnswerTypeOutputList}},
+		HostOverrides:   map[string][]string{},
+		AdditionalHosts: map[string][]string{},
+		NetworkPreset:   overlay.NetworkLocal,
+	}
+
+	ans, err := r.Query(context.Background(), &LookupQuestion{Service: "ls_test"})
+	require.NoError(t, err)
+	require.Equal(t, AnswerTypeOutputList, ans.Type)
+}
+
+// TestQuerySlapServiceUsesTrackers covers the ls_slap branch which routes to the
+// configured SLAP trackers.
+func TestQuerySlapServiceUsesTrackers(t *testing.T) {
+	t.Parallel()
+	r := &LookupResolver{
+		Facilitator:     &mockFacilitator{answer: &LookupAnswer{Type: AnswerTypeOutputList}},
+		HostOverrides:   map[string][]string{},
+		AdditionalHosts: map[string][]string{},
+		SLAPTrackers:    []string{"http://tracker"},
+	}
+
+	ans, err := r.Query(context.Background(), &LookupQuestion{Service: "ls_slap"})
+	require.NoError(t, err)
+	require.Equal(t, AnswerTypeOutputList, ans.Type)
+}
+
+// TestQueryAppendsAdditionalHosts covers the branch that appends additional
+// hosts on top of the resolved competent hosts.
+func TestQueryAppendsAdditionalHosts(t *testing.T) {
+	t.Parallel()
+	r := &LookupResolver{
+		Facilitator:     &mockFacilitator{answer: &LookupAnswer{Type: AnswerTypeOutputList}},
+		HostOverrides:   map[string][]string{"ls_test": {"http://host-a"}},
+		AdditionalHosts: map[string][]string{"ls_test": {"http://host-b"}},
+	}
+
+	ans, err := r.Query(context.Background(), &LookupQuestion{Service: "ls_test"})
+	require.NoError(t, err)
+	require.Equal(t, AnswerTypeOutputList, ans.Type)
+}
+
+// TestQuerySkipsNonOutputListResponse covers the branch that skips a successful
+// response whose type is neither freeform nor output-list.
+func TestQuerySkipsNonOutputListResponse(t *testing.T) {
+	t.Parallel()
+	r := newResolverWith(
+		&mockFacilitator{answer: &LookupAnswer{Type: AnswerTypeFormula}},
+		"ls_formula",
+		[]string{"http://host-a"},
+	)
+
+	ans, err := r.Query(context.Background(), &LookupQuestion{Service: "ls_formula"})
+	require.NoError(t, err)
+	require.Equal(t, AnswerTypeOutputList, ans.Type)
+	require.Empty(t, ans.Outputs)
+}
+
+// TestQuerySkipsInvalidBeefOutput covers the branch that logs and skips an
+// output whose BEEF cannot be parsed.
+func TestQuerySkipsInvalidBeefOutput(t *testing.T) {
+	t.Parallel()
+	r := newResolverWith(
+		&mockFacilitator{answer: &LookupAnswer{
+			Type:    AnswerTypeOutputList,
+			Outputs: []*OutputListItem{{Beef: []byte("invalid-beef"), OutputIndex: 0}},
+		}},
+		"ls_badbeef",
+		[]string{"http://host-a"},
+	)
+
+	ans, err := r.Query(context.Background(), &LookupQuestion{Service: "ls_badbeef"})
+	require.NoError(t, err)
+	require.Empty(t, ans.Outputs)
+}
+
+// TestFindCompetentHostsTrackerError covers the branch where a SLAP tracker
+// query errors and produces no responses.
+func TestFindCompetentHostsTrackerError(t *testing.T) {
+	t.Parallel()
+	r := &LookupResolver{
+		Facilitator:     &mockFacilitator{err: errors.New("tracker unreachable")},
+		HostOverrides:   map[string][]string{},
+		AdditionalHosts: map[string][]string{},
+		SLAPTrackers:    []string{"http://tracker"},
+	}
+
+	hosts, err := r.FindCompetentHosts(context.Background(), "ls_service")
+	require.NoError(t, err)
+	require.Empty(t, hosts)
+}
+
+// TestFindCompetentHostsSkipsInvalidBeef covers the branch that logs and skips a
+// tracker output with unparseable BEEF.
+func TestFindCompetentHostsSkipsInvalidBeef(t *testing.T) {
+	t.Parallel()
+	r := &LookupResolver{
+		Facilitator: &mockFacilitator{answer: &LookupAnswer{
+			Type:    AnswerTypeOutputList,
+			Outputs: []*OutputListItem{{Beef: []byte("invalid-beef"), OutputIndex: 0}},
+		}},
+		HostOverrides:   map[string][]string{},
+		AdditionalHosts: map[string][]string{},
+		SLAPTrackers:    []string{"http://tracker"},
+	}
+
+	hosts, err := r.FindCompetentHosts(context.Background(), "ls_service")
+	require.NoError(t, err)
+	require.Empty(t, hosts)
+}
+
+// TestFindCompetentHostsOutputIndexOutOfRange covers the branch where the
+// advertised output index exceeds the transaction's output count.
+func TestFindCompetentHostsOutputIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+	beef := tu.SingleOutputBeef(t, &script.Script{})
+	r := &LookupResolver{
+		Facilitator: &mockFacilitator{answer: &LookupAnswer{
+			Type:    AnswerTypeOutputList,
+			Outputs: []*OutputListItem{{Beef: beef, OutputIndex: 99}},
+		}},
+		HostOverrides:   map[string][]string{},
+		AdditionalHosts: map[string][]string{},
+		SLAPTrackers:    []string{"http://tracker"},
+	}
+
+	hosts, err := r.FindCompetentHosts(context.Background(), "ls_service")
+	require.NoError(t, err)
+	require.Empty(t, hosts)
+}

--- a/overlay/topic/broadcaster_paths_extra_test.go
+++ b/overlay/topic/broadcaster_paths_extra_test.go
@@ -1,0 +1,221 @@
+package topic
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/overlay"
+	"github.com/bsv-blockchain/go-sdk/overlay/lookup"
+	"github.com/bsv-blockchain/go-sdk/script"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+)
+
+// TestNewBroadcasterWithResolverConfig covers the branch where a Resolver is
+// supplied in the config (rather than defaulted).
+func TestNewBroadcasterWithResolverConfig(t *testing.T) {
+	t.Parallel()
+	resolver := lookup.NewLookupResolver(&lookup.LookupResolver{})
+	b, err := NewBroadcaster([]string{"tm_test"}, &BroadcasterConfig{Resolver: resolver})
+	require.NoError(t, err)
+	require.NotNil(t, b)
+}
+
+// TestBroadcastUsesBackgroundContext covers the plain Broadcast wrapper which
+// delegates to BroadcastCtx with a background context.
+func TestBroadcastUsesBackgroundContext(t *testing.T) {
+	t.Parallel()
+	tx := broadcastTestTx(t)
+	b := &Broadcaster{
+		Topics:        []string{"tm_test"},
+		Facilitator:   &mockBroadcastFacilitator{steak: ackSteak("tm_test")},
+		NetworkPreset: overlay.NetworkLocal,
+		AckFromAll:    AckFrom{RequireAck: RequireAckNone},
+		AckFromAny:    AckFrom{RequireAck: RequireAckNone},
+	}
+
+	success, failure := b.Broadcast(tx)
+	require.Nil(t, failure)
+	require.NotNil(t, success)
+}
+
+// TestBroadcastCtxFindInterestedHostsError covers the branch where non-local
+// host discovery fails and the broadcast returns a 500 failure.
+func TestBroadcastCtxFindInterestedHostsError(t *testing.T) {
+	t.Parallel()
+	tx := broadcastTestTx(t)
+	resolver := lookup.NewLookupResolver(&lookup.LookupResolver{
+		Facilitator:   &mockLookupFacilitator{err: errors.New("tracker down")},
+		HostOverrides: map[string][]string{"ls_ship": {"http://tracker"}},
+	})
+	b := &Broadcaster{
+		Topics:        []string{"tm_test"},
+		Facilitator:   &mockBroadcastFacilitator{steak: ackSteak("tm_test")},
+		Resolver:      *resolver,
+		NetworkPreset: overlay.NetworkMainnet,
+	}
+
+	success, failure := b.BroadcastCtx(context.Background(), tx)
+	require.Nil(t, success)
+	require.NotNil(t, failure)
+	require.Equal(t, "500", failure.Code)
+}
+
+// TestBroadcastCtxAckFromAllVariants covers the remaining AckFromAll switch
+// arms (RequireAckAny, RequireAckSome, and the default/unknown value).
+func TestBroadcastCtxAckFromAllVariants(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		ackFrom AckFrom
+	}{
+		{"require any", AckFrom{RequireAck: RequireAckAny}},
+		{"require some", AckFrom{RequireAck: RequireAckSome, Topics: []string{"tm_test"}}},
+		{"unknown value falls through to default", AckFrom{RequireAck: RequireAck(99)}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tx := broadcastTestTx(t)
+			b := &Broadcaster{
+				Topics:        []string{"tm_test"},
+				Facilitator:   &mockBroadcastFacilitator{steak: ackSteak("tm_test")},
+				NetworkPreset: overlay.NetworkLocal,
+				AckFromAll:    tc.ackFrom,
+				AckFromAny:    AckFrom{RequireAck: RequireAckNone},
+			}
+			success, failure := b.BroadcastCtx(context.Background(), tx)
+			require.Nil(t, failure)
+			require.NotNil(t, success)
+		})
+	}
+}
+
+// TestBroadcastCtxAckFromAnyVariants covers the remaining AckFromAny switch
+// arms (RequireAckSome, RequireAckAll, and the default/unknown value).
+func TestBroadcastCtxAckFromAnyVariants(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		ackFrom AckFrom
+	}{
+		{"require some", AckFrom{RequireAck: RequireAckSome, Topics: []string{"tm_test"}}},
+		{"require all", AckFrom{RequireAck: RequireAckAll}},
+		{"unknown value falls through to default", AckFrom{RequireAck: RequireAck(99)}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tx := broadcastTestTx(t)
+			b := &Broadcaster{
+				Topics:        []string{"tm_test"},
+				Facilitator:   &mockBroadcastFacilitator{steak: ackSteak("tm_test")},
+				NetworkPreset: overlay.NetworkLocal,
+				AckFromAll:    AckFrom{RequireAck: RequireAckNone},
+				AckFromAny:    tc.ackFrom,
+			}
+			success, failure := b.BroadcastCtx(context.Background(), tx)
+			require.Nil(t, failure)
+			require.NotNil(t, success)
+		})
+	}
+}
+
+// TestFindInterestedHostsWrongAnswerType covers the branch where the SHIP
+// tracker returns a non-output-list answer.
+func TestFindInterestedHostsWrongAnswerType(t *testing.T) {
+	t.Parallel()
+	resolver := lookup.NewLookupResolver(&lookup.LookupResolver{
+		Facilitator: &mockLookupFacilitator{answer: &lookup.LookupAnswer{
+			Type:   lookup.AnswerTypeFreeform,
+			Result: "not-an-output-list",
+		}},
+		HostOverrides: map[string][]string{"ls_ship": {"http://tracker"}},
+	})
+	b := &Broadcaster{
+		Topics:        []string{"tm_test"},
+		Resolver:      *resolver,
+		NetworkPreset: overlay.NetworkMainnet,
+	}
+
+	_, err := b.FindInterestedHosts(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not an output list")
+}
+
+// TestFindInterestedHostsNonAdminTokenSkipped covers the branch where an output
+// carries a valid BEEF whose locking script is not an admin token.
+func TestFindInterestedHostsNonAdminTokenSkipped(t *testing.T) {
+	t.Parallel()
+	// A plain locking script (not a pushdrop admin token) decodes to nil.
+	plainScript := &script.Script{}
+	require.NoError(t, plainScript.AppendOpcodes(script.OpTRUE))
+	beef := tu.SingleOutputBeef(t, plainScript)
+
+	resolver := lookup.NewLookupResolver(&lookup.LookupResolver{
+		Facilitator: &mockLookupFacilitator{answer: &lookup.LookupAnswer{
+			Type:    lookup.AnswerTypeOutputList,
+			Outputs: []*lookup.OutputListItem{{Beef: beef, OutputIndex: 0}},
+		}},
+		HostOverrides: map[string][]string{"ls_ship": {"http://tracker"}},
+	})
+	b := &Broadcaster{
+		Topics:        []string{"tm_test"},
+		Resolver:      *resolver,
+		NetworkPreset: overlay.NetworkMainnet,
+	}
+
+	hosts, err := b.FindInterestedHosts(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, hosts)
+}
+
+// TestFindInterestedHostsWrongProtocolOrTopicSkipped covers the branch where an
+// admin token is decoded but is not a SHIP advertisement for a matching topic.
+func TestFindInterestedHostsWrongProtocolOrTopicSkipped(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		token []byte
+	}{
+		{"wrong protocol (SLAP)", tu.BuildAdminTokenBeef(t, "SLAP", "http://host", "tm_test")},
+		{"wrong topic", tu.BuildAdminTokenBeef(t, "SHIP", "http://host", "tm_other")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resolver := lookup.NewLookupResolver(&lookup.LookupResolver{
+				Facilitator: &mockLookupFacilitator{answer: &lookup.LookupAnswer{
+					Type:    lookup.AnswerTypeOutputList,
+					Outputs: []*lookup.OutputListItem{{Beef: tc.token, OutputIndex: 0}},
+				}},
+				HostOverrides: map[string][]string{"ls_ship": {"http://tracker"}},
+			})
+			b := &Broadcaster{
+				Topics:        []string{"tm_test"},
+				Resolver:      *resolver,
+				NetworkPreset: overlay.NetworkMainnet,
+			}
+
+			hosts, err := b.FindInterestedHosts(context.Background())
+			require.NoError(t, err)
+			require.Empty(t, hosts)
+		})
+	}
+}
+
+// TestCheckAcknowledgmentFromSpecificHostsUnknownRequireAck covers the default
+// arm of the per-host requirement switch (an unknown RequireAck is skipped).
+func TestCheckAcknowledgmentFromSpecificHostsUnknownRequireAck(t *testing.T) {
+	t.Parallel()
+	b := &Broadcaster{Topics: []string{"tm_a"}}
+	hostAcks := map[string]map[string]struct{}{
+		"host1": {},
+	}
+	requirements := map[string]AckFrom{
+		"host1": {RequireAck: RequireAck(99)},
+	}
+	require.True(t, b.checkAcknowledgmentFromSpecificHosts(hostAcks, requirements))
+}

--- a/primitives/ec/coverage_extra_test.go
+++ b/primitives/ec/coverage_extra_test.go
@@ -1,0 +1,237 @@
+package primitives
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignatureDERRoundTrip covers ToDER and FromDER, including the FromDER
+// error branch on malformed input.
+func TestSignatureDERRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	priv, err := NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i)
+	}
+
+	sig, err := priv.Sign(hash)
+	require.NoError(t, err)
+
+	der, err := sig.ToDER()
+	require.NoError(t, err)
+	require.NotEmpty(t, der)
+
+	got, err := FromDER(der)
+	require.NoError(t, err)
+	require.Zero(t, got.R.Cmp(sig.R))
+	require.Zero(t, got.S.Cmp(sig.S))
+
+	t.Run("malformed DER returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := FromDER([]byte{0xff, 0x00, 0x01})
+		require.Error(t, err)
+	})
+}
+
+// TestPublicKeyJSONMarshalling covers MarshalJSON and UnmarshalJSON including
+// error branches.
+func TestPublicKeyJSONMarshalling(t *testing.T) {
+	t.Parallel()
+
+	priv, err := NewPrivateKey()
+	require.NoError(t, err)
+	pub := priv.PubKey()
+
+	data, err := json.Marshal(pub)
+	require.NoError(t, err)
+
+	var decoded PublicKey
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.True(t, pub.IsEqual(&decoded))
+
+	t.Run("nil pubkey marshals to null", func(t *testing.T) {
+		t.Parallel()
+		var p *PublicKey
+		b, err := p.MarshalJSON()
+		require.NoError(t, err)
+		require.JSONEq(t, "null", string(b))
+	})
+
+	t.Run("unmarshal non-string fails", func(t *testing.T) {
+		t.Parallel()
+		var p PublicKey
+		require.Error(t, p.UnmarshalJSON([]byte("123")))
+	})
+
+	t.Run("unmarshal invalid hex fails", func(t *testing.T) {
+		t.Parallel()
+		var p PublicKey
+		require.Error(t, p.UnmarshalJSON([]byte(`"zzzz"`)))
+	})
+}
+
+// TestPublicKeyFromBytesAndString covers PublicKeyFromBytes and the error
+// branches of PublicKeyFromString.
+func TestPublicKeyFromBytesAndString(t *testing.T) {
+	t.Parallel()
+
+	priv, err := NewPrivateKey()
+	require.NoError(t, err)
+	pub := priv.PubKey()
+	compressed := pub.Compressed()
+
+	t.Run("from bytes valid", func(t *testing.T) {
+		t.Parallel()
+		got, err := PublicKeyFromBytes(compressed)
+		require.NoError(t, err)
+		require.True(t, pub.IsEqual(got))
+	})
+
+	t.Run("from bytes invalid", func(t *testing.T) {
+		t.Parallel()
+		_, err := PublicKeyFromBytes([]byte{0x02, 0x00})
+		require.Error(t, err)
+	})
+
+	t.Run("from string bad hex", func(t *testing.T) {
+		t.Parallel()
+		_, err := PublicKeyFromString("zzz")
+		require.Error(t, err)
+	})
+
+	t.Run("from string valid hex bad point", func(t *testing.T) {
+		t.Parallel()
+		_, err := PublicKeyFromString("0200")
+		require.Error(t, err)
+	})
+}
+
+// TestDeriveSharedSecretNotOnCurve covers the error branch of DeriveSharedSecret
+// when the public key is not a valid curve point.
+func TestDeriveSharedSecretNotOnCurve(t *testing.T) {
+	t.Parallel()
+
+	priv, err := NewPrivateKey()
+	require.NoError(t, err)
+
+	badPub := &PublicKey{
+		Curve: S256(),
+		X:     big.NewInt(1),
+		Y:     big.NewInt(1),
+	}
+	_, err = badPub.DeriveSharedSecret(priv)
+	require.Error(t, err)
+}
+
+// TestSymmetricKeyStringHelpers covers EncryptString, DecryptString and FromBytes.
+func TestSymmetricKeyStringHelpers(t *testing.T) {
+	t.Parallel()
+
+	key := NewSymmetricKeyFromRandom()
+
+	t.Run("encrypt/decrypt string round trip", func(t *testing.T) {
+		t.Parallel()
+		const msg = "the quick brown fox"
+		ct, err := key.EncryptString(msg)
+		require.NoError(t, err)
+		require.NotEmpty(t, ct)
+
+		pt, err := key.DecryptString(ct)
+		require.NoError(t, err)
+		require.Equal(t, msg, pt)
+	})
+
+	t.Run("decrypt string too short fails", func(t *testing.T) {
+		t.Parallel()
+		_, err := key.DecryptString("short")
+		require.Error(t, err)
+	})
+
+	t.Run("from bytes builds usable key", func(t *testing.T) {
+		t.Parallel()
+		raw := make([]byte, 32)
+		for i := range raw {
+			raw[i] = byte(i + 1)
+		}
+		built := (&SymmetricKey{}).FromBytes(raw)
+		require.Equal(t, raw, built.ToBytes())
+
+		ct, err := built.Encrypt([]byte("hi"))
+		require.NoError(t, err)
+		pt, err := built.Decrypt(ct)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hi"), pt)
+	})
+}
+
+// TestCurveDouble covers the KoblitzCurve.Double method, both the zero-y
+// short-circuit and the general point doubling path.
+func TestCurveDouble(t *testing.T) {
+	t.Parallel()
+
+	curve := S256()
+
+	t.Run("zero y returns point at infinity", func(t *testing.T) {
+		t.Parallel()
+		x, y := curve.Double(big.NewInt(5), big.NewInt(0))
+		require.Zero(t, x.Sign())
+		require.Zero(t, y.Sign())
+	})
+
+	t.Run("doubles the generator point", func(t *testing.T) {
+		t.Parallel()
+		x, y := curve.Double(curve.Gx, curve.Gy)
+		require.True(t, curve.IsOnCurve(x, y))
+		// Doubling G must match ScalarBaseMult(2).
+		ex, ey := curve.ScalarBaseMult([]byte{2})
+		require.Zero(t, x.Cmp(ex))
+		require.Zero(t, y.Cmp(ey))
+	})
+}
+
+// TestCurveConstants covers QPlus1Div4 and Q.
+func TestCurveConstants(t *testing.T) {
+	t.Parallel()
+
+	curve := S256()
+	require.NotNil(t, curve.QPlus1Div4())
+	require.NotNil(t, curve.Q())
+	require.Zero(t, curve.QPlus1Div4().Cmp(curve.Q()))
+}
+
+// TestFromHexPanicsOnInvalid covers the panic branch of FromHex.
+func TestFromHexPanicsOnInvalid(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, FromHex("ff"))
+	require.Panics(t, func() {
+		_ = FromHex("nothex")
+	})
+}
+
+// TestModuloReduce covers the long-input reduction branch of moduloReduce.
+func TestModuloReduce(t *testing.T) {
+	t.Parallel()
+
+	curve := S256()
+
+	// Input longer than the curve byte size triggers the modulo path.
+	long, err := hex.DecodeString(
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+	)
+	require.NoError(t, err)
+	reduced := curve.moduloReduce(long)
+	require.LessOrEqual(t, len(reduced), curve.byteSize)
+
+	// Short input is returned effectively unchanged (<= byteSize).
+	short := curve.moduloReduce([]byte{0x01, 0x02})
+	require.LessOrEqual(t, len(short), curve.byteSize)
+}

--- a/registry/registry_paths_extra_test.go
+++ b/registry/registry_paths_extra_test.go
@@ -1,0 +1,159 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/overlay"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+const revokeTestTxID = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+// unsupportedDefinition is a DefinitionData whose concrete type is not one of
+// the three known registry types, forcing buildPushDropFields to fail.
+type unsupportedDefinition struct{}
+
+func (unsupportedDefinition) GetDefinitionType() DefinitionType { return DefinitionType("mystery") }
+func (unsupportedDefinition) GetRegistryOperator() string       { return "" }
+
+func TestRegisterDefinitionBuildFieldsError(t *testing.T) {
+	mw := NewMockRegistry(t)
+	mw.GetPublicKeyResult = &wallet.GetPublicKeyResult{PublicKey: makeTestPubKey(t)}
+
+	client := NewRegistryClient(mw, "originator")
+	client.SetNetwork(overlay.NetworkLocal)
+
+	_, err := client.RegisterDefinition(context.Background(), unsupportedDefinition{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build push drop fields")
+}
+
+func TestRegisterDefinitionLockError(t *testing.T) {
+	mw := NewMockRegistry(t)
+	mw.GetPublicKeyResult = &wallet.GetPublicKeyResult{PublicKey: makeTestPubKey(t)}
+	mw.CreateSignatureError = errors.New("cannot sign locking script")
+
+	client := NewRegistryClient(mw, "originator")
+	client.SetNetwork(overlay.NetworkLocal)
+
+	_, err := client.RegisterDefinition(context.Background(), &BasketDefinitionData{
+		DefinitionType: DefinitionTypeBasket, BasketID: "b1", Name: "N",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create locking script")
+}
+
+func TestRegisterDefinitionCreateActionError(t *testing.T) {
+	mw := &walletWithCreateActionError{MockRegistry: NewMockRegistry(t), err: errors.New("wallet busy")}
+	mw.GetPublicKeyResult = &wallet.GetPublicKeyResult{PublicKey: makeTestPubKey(t)}
+	mw.CreateSignatureResult = &wallet.CreateSignatureResult{
+		Signature: &ec.Signature{R: big.NewInt(1), S: big.NewInt(1)},
+	}
+
+	client := NewRegistryClient(mw, "originator")
+	client.SetNetwork(overlay.NetworkLocal)
+
+	_, err := client.RegisterDefinition(context.Background(), &BasketDefinitionData{
+		DefinitionType: DefinitionTypeBasket, BasketID: "b1", Name: "N",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create transaction")
+}
+
+func TestRegisterDefinitionInvalidCreatedBEEF(t *testing.T) {
+	mw := NewMockRegistry(t)
+	mw.GetPublicKeyResult = &wallet.GetPublicKeyResult{PublicKey: makeTestPubKey(t)}
+	mw.CreateSignatureResult = &wallet.CreateSignatureResult{
+		Signature: &ec.Signature{R: big.NewInt(1), S: big.NewInt(1)},
+	}
+	mw.CreateActionResultToReturn = &wallet.CreateActionResult{Tx: []byte("not-valid-beef")}
+
+	client := NewRegistryClient(mw, "originator")
+	client.SetNetwork(overlay.NetworkLocal)
+	client.SetBroadcasterFactory(successBroadcasterFactory("aabbcc"))
+
+	_, err := client.RegisterDefinition(context.Background(), &BasketDefinitionData{
+		DefinitionType: DefinitionTypeBasket, BasketID: "b1", Name: "N",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create transaction from BEEF")
+}
+
+func TestRevokeOwnRegistryEntryUnlockerSignError(t *testing.T) {
+	key := makeTestPubKey(t)
+	beef := decodeValidBeef(t)
+	mw := NewMockRegistry(t)
+	mw.GetPublicKeyResult = &wallet.GetPublicKeyResult{PublicKey: key}
+	mw.CreateActionResultToReturn = &wallet.CreateActionResult{
+		SignableTransaction: &wallet.SignableTransaction{Tx: beef, Reference: []byte("ref")},
+	}
+	mw.CreateSignatureError = errors.New("cannot sign spend")
+
+	record := &RegistryRecord{
+		DefinitionData: &BasketDefinitionData{
+			DefinitionType:   DefinitionTypeBasket,
+			RegistryOperator: key.ToDERHex(),
+		},
+		TokenData: TokenData{
+			TxID:          revokeTestTxID,
+			LockingScript: testSomeScript,
+			BEEF:          beef,
+		},
+	}
+
+	client := NewRegistryClient(mw, "originator")
+	client.SetNetwork(overlay.NetworkLocal)
+	_, err := client.RevokeOwnRegistryEntry(context.Background(), record)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to sign transaction")
+}
+
+func TestRevokeOwnRegistryEntryDefaultBroadcasterFallback(t *testing.T) {
+	// With a nil broadcaster factory, RevokeOwnRegistryEntry falls back to the
+	// default topic.NewBroadcaster. Outbound HTTP is disabled so the broadcast
+	// itself yields a failure rather than a transport error.
+	tu.WithUnreachableTransport(t)
+
+	key := makeTestPubKey(t)
+	beef := decodeValidBeef(t)
+	txID := mockTxid(t)
+	mw := NewMockRegistry(t)
+	mw.GetPublicKeyResult = &wallet.GetPublicKeyResult{PublicKey: key}
+	mw.CreateActionResultToReturn = &wallet.CreateActionResult{
+		SignableTransaction: &wallet.SignableTransaction{Tx: beef, Reference: []byte("ref")},
+	}
+	mw.CreateSignatureResult = &wallet.CreateSignatureResult{
+		Signature: &ec.Signature{R: big.NewInt(1), S: big.NewInt(1)},
+	}
+	mw.SignActionResultToReturn = &wallet.SignActionResult{Tx: beef, Txid: *txID}
+
+	record := &RegistryRecord{
+		DefinitionData: &BasketDefinitionData{
+			DefinitionType:   DefinitionTypeBasket,
+			RegistryOperator: key.ToDERHex(),
+		},
+		TokenData: TokenData{
+			TxID:          revokeTestTxID,
+			LockingScript: testSomeScript,
+			BEEF:          beef,
+		},
+	}
+
+	client := NewRegistryClient(mw, "originator")
+	client.SetNetwork(overlay.NetworkLocal)
+	client.SetBroadcasterFactory(nil) // force the default-broadcaster fallback
+
+	result, err := client.RevokeOwnRegistryEntry(context.Background(), record)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Success)
+	require.NotNil(t, result.Failure)
+}

--- a/script/interpreter/coverage_extra_test.go
+++ b/script/interpreter/coverage_extra_test.go
@@ -1,0 +1,163 @@
+package interpreter
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter/scriptflag"
+)
+
+// TestNopDebugger exercises every method on the no-op debugger so that the
+// default (undebugged) execution path's helper type is fully covered.
+func TestNopDebugger(t *testing.T) {
+	t.Parallel()
+
+	d := &nopDebugger{}
+	st := &State{}
+
+	require.NotPanics(t, func() {
+		d.BeforeExecute(st)
+		d.AfterExecute(st)
+		d.BeforeStep(st)
+		d.AfterStep(st)
+		d.BeforeExecuteOpcode(st)
+		d.AfterExecuteOpcode(st)
+		d.BeforeScriptChange(st)
+		d.AfterScriptChange(st)
+		d.BeforeStackPush(st, []byte{0x01})
+		d.AfterStackPush(st, []byte{0x01})
+		d.BeforeStackPop(st)
+		d.AfterStackPop(st, []byte{0x01})
+		d.AfterSuccess(st)
+		d.AfterError(st, nil)
+	})
+}
+
+// TestNopStateHandler covers the no-op state handler helpers.
+func TestNopStateHandler(t *testing.T) {
+	t.Parallel()
+
+	h := &nopStateHandler{}
+	require.NotNil(t, h.State())
+	require.NotPanics(t, func() {
+		h.SetState(&State{})
+	})
+}
+
+// TestNopBoolStack covers the no-op bool stack helper methods.
+func TestNopBoolStack(t *testing.T) {
+	t.Parallel()
+
+	n := &nopBoolStack{}
+	n.PushBool(true)
+
+	b, err := n.PeekBool(0)
+	require.NoError(t, err)
+	require.False(t, b)
+
+	require.Equal(t, int32(0), n.Depth())
+}
+
+// TestStackString covers the String rendering of a stack, both with populated
+// and empty entries.
+func TestStackString(t *testing.T) {
+	t.Parallel()
+
+	s := &stack{debug: &nopDebugger{}, sh: &nopStateHandler{}}
+	s.PushByteArray([]byte{0xde, 0xad})
+	s.PushByteArray(nil) // empty entry exercises the <empty> branch
+
+	out := s.String()
+	require.Contains(t, out, "<empty>")
+	require.NotEmpty(t, out)
+}
+
+// TestParsedOpcodeValueLength covers ParsedOpcode.Value and ParsedOpcode.Length.
+func TestParsedOpcodeValueLength(t *testing.T) {
+	t.Parallel()
+
+	scr := &script.Script{}
+	require.NoError(t, scr.AppendOpcodes(script.Op1))
+
+	var parser DefaultOpcodeParser
+	parsed, err := parser.Parse(scr)
+	require.NoError(t, err)
+	require.Len(t, parsed, 1)
+
+	require.Equal(t, script.Op1, parsed[0].Value())
+	require.Equal(t, 1, parsed[0].Length())
+}
+
+// TestExecOptionsExtra covers WithP2SH and WithDebugger option setters.
+func TestExecOptionsExtra(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithP2SH sets Bip16", func(t *testing.T) {
+		t.Parallel()
+		opts := &execOpts{}
+		WithP2SH()(opts)
+		require.True(t, opts.flags.HasFlag(scriptflag.Bip16))
+	})
+
+	t.Run("WithDebugger sets debugger", func(t *testing.T) {
+		t.Parallel()
+		opts := &execOpts{}
+		d := &nopDebugger{}
+		WithDebugger(d)(opts)
+		require.Equal(t, d, opts.debugger)
+	})
+}
+
+// TestConfigExtra covers the config accessors that are not otherwise exercised.
+func TestConfigExtra(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, (&afterGenesisConfig{}).AfterChronicle())
+	require.False(t, (&beforeGenesisConfig{}).AfterChronicle())
+	require.Equal(t, math.MaxInt32, (&afterChronicleConfig{}).MaxPubKeysPerMultiSig())
+}
+
+// captureDebugger records that state accessors are reachable during a real
+// execution driven through WithDebugger. It embeds the Debugger interface so
+// only the callbacks of interest need overriding.
+type captureDebugger struct {
+	Debugger
+
+	sawOpcode bool
+	steps     int
+}
+
+func (c *captureDebugger) BeforeExecuteOpcode(s *State) {
+	c.steps++
+	if len(s.RemainingScript()) > 0 {
+		// Opcode reads Scripts[ScriptIdx][OpcodeIdx]; the thread clamps the
+		// indices so this is always a valid access mid-execution.
+		_ = s.Opcode()
+		c.sawOpcode = true
+	}
+}
+
+// TestEngineWithDebuggerState drives a real (successful) execution with a
+// debugger installed. This exercises thread.State, State.Opcode and
+// State.RemainingScript via the live state-cloning path.
+func TestEngineWithDebuggerState(t *testing.T) {
+	t.Parallel()
+
+	uscript, err := script.NewFromHex("52") // OP_2
+	require.NoError(t, err)
+	lscript, err := script.NewFromHex("5287") // OP_2 OP_EQUAL
+	require.NoError(t, err)
+
+	dbg := &captureDebugger{Debugger: &nopDebugger{}}
+
+	require.NoError(t, NewEngine().Execute(
+		WithScripts(lscript, uscript),
+		WithDebugger(dbg),
+	))
+
+	require.Positive(t, dbg.steps)
+	require.True(t, dbg.sawOpcode)
+}

--- a/script/script_coverage_extra_test.go
+++ b/script/script_coverage_extra_test.go
@@ -1,0 +1,145 @@
+package script_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	script "github.com/bsv-blockchain/go-sdk/script"
+)
+
+// TestNewFromHexInvalid covers the error branch of NewFromHex.
+func TestNewFromHexInvalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := script.NewFromHex("zz")
+	require.Error(t, err)
+}
+
+// TestNewFromASMInvalid covers the error branch of NewFromASM where a section is
+// neither a known opcode nor valid push data.
+func TestNewFromASMInvalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := script.NewFromASM("zzz")
+	require.ErrorIs(t, err, script.ErrInvalidOpCode)
+}
+
+// TestAppendPushDataHexInvalid covers the error branch of AppendPushDataHex.
+func TestAppendPushDataHexInvalid(t *testing.T) {
+	t.Parallel()
+
+	s := &script.Script{}
+	require.Error(t, s.AppendPushDataHex("zz"))
+}
+
+// TestUnmarshalJSONInvalid covers the error branch of UnmarshalJSON.
+func TestUnmarshalJSONInvalid(t *testing.T) {
+	t.Parallel()
+
+	var s script.Script
+	require.Error(t, json.Unmarshal([]byte(`"zz"`), &s))
+}
+
+// TestPublicKeyHashErrors covers the error branches of PublicKeyHash.
+func TestPublicKeyHashErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil script", func(t *testing.T) {
+		t.Parallel()
+		var s *script.Script
+		_, err := s.PublicKeyHash()
+		require.ErrorIs(t, err, script.ErrEmptyScript)
+	})
+
+	t.Run("empty script", func(t *testing.T) {
+		t.Parallel()
+		s := &script.Script{}
+		_, err := s.PublicKeyHash()
+		require.ErrorIs(t, err, script.ErrEmptyScript)
+	})
+
+	t.Run("not P2PKH", func(t *testing.T) {
+		t.Parallel()
+		s, err := script.NewFromHex("51")
+		require.NoError(t, err)
+		_, err = s.PublicKeyHash()
+		require.ErrorIs(t, err, script.ErrNotP2PKH)
+	})
+}
+
+// TestAddressNotP2PKH covers the not-P2PKH error branch of Address.
+func TestAddressNotP2PKH(t *testing.T) {
+	t.Parallel()
+
+	s, err := script.NewFromHex("51")
+	require.NoError(t, err)
+	_, err = s.Address()
+	require.Error(t, err)
+}
+
+// TestPubKeyNotP2PK covers the not-P2PK error branches of PubKey and PubKeyHex.
+func TestPubKeyNotP2PK(t *testing.T) {
+	t.Parallel()
+
+	s, err := script.NewFromHex("51")
+	require.NoError(t, err)
+
+	_, err = s.PubKey()
+	require.Error(t, err)
+
+	_, err = s.PubKeyHex()
+	require.Error(t, err)
+}
+
+// TestAddressesNonP2PKH covers the branch of Addresses where the script is not a
+// P2PKH script and an empty slice is returned.
+func TestAddressesNonP2PKH(t *testing.T) {
+	t.Parallel()
+
+	s, err := script.NewFromHex("51")
+	require.NoError(t, err)
+
+	addrs, err := s.Addresses()
+	require.NoError(t, err)
+	require.Empty(t, addrs)
+}
+
+// TestMinPushSizeLargeData covers the PUSHDATA2 and PUSHDATA4 size branches of
+// MinPushSize as well as the single-byte encodings.
+func TestMinPushSizeLargeData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		size int
+		want int
+	}{
+		{name: "empty", size: 0, want: 1},
+		{name: "single data byte", size: 1, want: 2},
+		{name: "op_data boundary", size: 75, want: 76},
+		{name: "pushdata1", size: 200, want: 202},
+		{name: "pushdata2", size: 300, want: 303},
+		{name: "pushdata4", size: 70000, want: 70005},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data := make([]byte, tc.size)
+			for i := range data {
+				data[i] = 0xab // ensure non-small-int content for size 1
+			}
+			require.Equal(t, tc.want, script.MinPushSize(data))
+		})
+	}
+}
+
+// TestMinPushSizeSmallInt covers the single-byte small-int / OP_NEGATE branch.
+func TestMinPushSizeSmallInt(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 1, script.MinPushSize([]byte{0x10})) // 16 -> OP_16
+	require.Equal(t, 1, script.MinPushSize([]byte{0x81})) // OP_1NEGATE
+}

--- a/storage/storage_coverage_extra_test.go
+++ b/storage/storage_coverage_extra_test.go
@@ -1,0 +1,59 @@
+package storage
+
+// storage_coverage_extra_test.go – covers remaining reachable error branches:
+//   - GetHashFromURL: prefix-mismatch path (utils.go)
+//   - FindFile: url.Parse failure on a malformed base URL (uploader.go)
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	base58 "github.com/bsv-blockchain/go-sdk/compat/base58"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// encodeUHRPPayload builds a Base58Check-style UHRP payload with the supplied
+// 2-byte prefix, a fixed 32-byte hash and a 4-byte checksum, then Base58 encodes
+// it. The checksum is intentionally arbitrary; callers testing the prefix branch
+// never reach checksum validation.
+func encodeUHRPPayload(prefix [2]byte) string {
+	payload := make([]byte, 0, prefixLength+minHashLength+4)
+	payload = append(payload, prefix[0], prefix[1])
+	for i := 0; i < minHashLength; i++ {
+		payload = append(payload, 0x11)
+	}
+	payload = append(payload, 0xaa, 0xbb, 0xcc, 0xdd)
+	return base58.Encode(payload)
+}
+
+func TestGetHashFromURLPrefixMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Correct decoded length (38 bytes) but a prefix other than [0xce, 0x00]
+	// exercises the ErrInvalidURLPrefix branch before checksum validation.
+	url := encodeUHRPPayload([2]byte{0xce, 0x01})
+
+	_, err := GetHashFromURL(url)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidURLPrefix)
+}
+
+func TestFindFileInvalidBaseURL(t *testing.T) {
+	t.Parallel()
+
+	// A base URL containing a control character is accepted by NewUploader
+	// (which only checks for emptiness) but fails url.Parse inside FindFile.
+	w := wallet.NewTestWalletForRandomKey(t)
+	uploader, err := NewUploader(UploaderConfig{
+		StorageURL: "http://foo\x7fbar",
+		Wallet:     w,
+	})
+	require.NoError(t, err)
+
+	_, err = uploader.FindFile(context.Background(), "uhrp://example")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse find URL")
+}

--- a/transaction/bdk/bdk_extra_test.go
+++ b/transaction/bdk/bdk_extra_test.go
@@ -1,0 +1,19 @@
+//go:build cgo && !ios && !android && (darwin || linux) && (amd64 || arm64)
+
+package bdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFinalizeValidateBatch exercises the GC finalizer hook directly, which is
+// otherwise only invoked non-deterministically by the runtime.
+func TestFinalizeValidateBatch(t *testing.T) {
+	batch := NewValidateBatch()
+	require.NotNil(t, batch)
+
+	finalizeValidateBatch(batch)
+	require.True(t, batch.Empty())
+}

--- a/transaction/beef_extra_test.go
+++ b/transaction/beef_extra_test.go
@@ -1,0 +1,493 @@
+package transaction
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+)
+
+func le32(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return b
+}
+
+// simpleFundedChild builds a child transaction that spends a parent output, so
+// NewBeefFromTransaction has an ancestry to walk.
+func simpleFundedChild(t *testing.T) *Transaction {
+	t.Helper()
+	src := NewTransaction()
+	src.AddOutput(&TransactionOutput{Satoshis: 1000, LockingScript: &script.Script{}})
+	child := NewTransaction()
+	child.AddInputFromTx(src, 0, nil)
+	child.AddOutput(&TransactionOutput{Satoshis: 900, LockingScript: &script.Script{}})
+	return child
+}
+
+func TestBeefBumpRootError(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+	_, err := b.bumpRoot(brokenTwoLevelPath(1, mpHashA(t)))
+	require.Error(t, err)
+}
+
+func TestBeefBumpProvesGuards(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+	assert.False(t, b.bumpProves(singleLeafPath(1, mpHashA(t)), nil))
+	assert.False(t, b.bumpProves(&MerklePath{BlockHeight: 1}, mpHashA(t)))
+}
+
+func TestNewBeefFromBytesErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "atomic-too-short", data: append(le32(ATOMIC_BEEF), make([]byte, 10)...)},
+		{name: "bad-version-read", data: []byte{0x00, 0x00}},
+		{name: "v1-bumps-eof", data: le32(BEEF_V1)},
+		{name: "v1-transactions-eof", data: append(le32(BEEF_V1), 0x00)},
+		{name: "v2-bumps-eof", data: le32(BEEF_V2)},
+		{name: "bumps-count-overflow", data: append(le32(BEEF_V2), 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)},
+		{name: "bump-parse-error", data: append(le32(BEEF_V2), 0x01, 0x00, 0x01)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewBeefFromBytes(tc.data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNewBeefFromBytesAtomicRoundTrip(t *testing.T) {
+	t.Parallel()
+	child := simpleFundedChild(t)
+	b, err := NewBeefFromTransaction(child)
+	require.NoError(t, err)
+
+	atomic, err := b.AtomicBytes(child.TxID())
+	require.NoError(t, err)
+
+	parsed, err := NewBeefFromBytes(atomic)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.FindTransaction(child.TxID().String()))
+}
+
+func TestNewBeefFromAtomicBytesBodyInvalid(t *testing.T) {
+	t.Parallel()
+	data := append(le32(ATOMIC_BEEF), make([]byte, 32)...)
+	data = append(data, 0x00, 0x00) // body too short for readVersion
+	_, _, err := NewBeefFromAtomicBytes(data)
+	require.Error(t, err)
+}
+
+func TestParseBeefErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "atomic-too-short", data: append(le32(ATOMIC_BEEF), make([]byte, 10)...)},
+		{name: "atomic-body-invalid", data: append(append(le32(ATOMIC_BEEF), make([]byte, 32)...), 0x00, 0x00)},
+		{name: "v1-transaction-invalid", data: le32(BEEF_V1)},
+		{name: "v2-invalid", data: le32(BEEF_V2)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, _, err := ParseBeef(tc.data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNewBeefFromTransactionErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewBeefFromTransaction(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("missing-ancestor", func(t *testing.T) {
+		t.Parallel()
+		tx := NewTransaction()
+		tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+		tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+		_, err := NewBeefFromTransaction(tx)
+		require.Error(t, err)
+	})
+}
+
+func TestCollectAncestorsGrandparentMissing(t *testing.T) {
+	t.Parallel()
+	// b spends a missing grandparent; a spends b. Collecting a's ancestry must
+	// surface the recursive failure.
+	b := NewTransaction()
+	b.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+	b.AddOutput(&TransactionOutput{Satoshis: 500, LockingScript: &script.Script{}})
+
+	a := NewTransaction()
+	a.AddInputFromTx(b, 0, nil)
+	a.AddOutput(&TransactionOutput{Satoshis: 400, LockingScript: &script.Script{}})
+
+	_, err := NewBeefFromTransaction(a)
+	require.Error(t, err)
+}
+
+func TestReadBUMPsAndTransactionsErrors(t *testing.T) {
+	t.Parallel()
+	// Valid empty-BUMP prefix, then malformed transaction section.
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "tx-read-error", data: buildV1(0x00, []byte{0x01, 0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})},
+		{name: "hasbump-eof", data: buildV1(0x00, append([]byte{0x01}, minimalTxBytes()...))},
+		{name: "pathindex-eof", data: buildV1(0x00, append(append([]byte{0x01}, minimalTxBytes()...), 0x01))},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewBeefFromBytes(tc.data)
+			require.Error(t, err)
+		})
+	}
+}
+
+// buildV1 assembles a BEEF v1 byte stream: version, a bump count byte, and a raw
+// transaction section.
+func buildV1(bumpCount byte, txSection []byte) []byte {
+	out := le32(BEEF_V1)
+	out = append(out, bumpCount)
+	return append(out, txSection...)
+}
+
+func minimalTxBytes() []byte {
+	tx := NewTransaction()
+	return tx.Bytes()
+}
+
+func TestBeefFindHelpersInvalidInput(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+	assert.Nil(t, b.FindBumpByHash(nil))
+	assert.Nil(t, b.FindBump("zz"))
+	assert.Nil(t, b.FindTransaction("zz"))
+	assert.Nil(t, b.FindTransactionForSigning("zz"))
+	assert.Nil(t, b.FindTransactionForSigningByHash(mpHashA(t)))
+	assert.Nil(t, b.FindAtomicTransaction("zz"))
+	assert.Nil(t, b.FindAtomicTransactionByHash(mpHashA(t)))
+}
+
+func TestFindTransactionForSigningLinksSource(t *testing.T) {
+	t.Parallel()
+	src := NewTransaction()
+	src.AddOutput(&TransactionOutput{Satoshis: 1000, LockingScript: &script.Script{}})
+	child := NewTransaction()
+	child.AddInput(&TransactionInput{SourceTXID: src.TxID(), SourceTxOutIndex: 0, SequenceNumber: DefaultSequenceNumber})
+	child.AddOutput(&TransactionOutput{Satoshis: 900, LockingScript: &script.Script{}})
+
+	b := NewBeef()
+	b.Transactions[*src.TxID()] = &BeefTx{DataFormat: RawTx, Transaction: src}
+	b.Transactions[*child.TxID()] = &BeefTx{DataFormat: RawTx, Transaction: child}
+
+	got := b.FindTransactionForSigningByHash(child.TxID())
+	require.NotNil(t, got)
+	require.NotNil(t, child.Inputs[0].SourceTransaction)
+}
+
+func TestFindAtomicTransactionLinksSources(t *testing.T) {
+	t.Parallel()
+	src := NewTransaction()
+	src.AddOutput(&TransactionOutput{Satoshis: 1000, LockingScript: &script.Script{}})
+
+	missing := mpHashB(t)
+	child := NewTransaction()
+	child.AddInput(&TransactionInput{SourceTXID: src.TxID(), SourceTxOutIndex: 0, SequenceNumber: DefaultSequenceNumber})
+	child.AddInput(&TransactionInput{SourceTXID: missing, SourceTxOutIndex: 0, SequenceNumber: DefaultSequenceNumber})
+	child.AddOutput(&TransactionOutput{Satoshis: 900, LockingScript: &script.Script{}})
+
+	b := NewBeef()
+	b.Transactions[*src.TxID()] = &BeefTx{DataFormat: RawTx, Transaction: src}
+	b.Transactions[*child.TxID()] = &BeefTx{DataFormat: RawTx, Transaction: child}
+
+	got := b.FindAtomicTransactionByHash(child.TxID())
+	require.NotNil(t, got)
+	require.NotNil(t, child.Inputs[0].SourceTransaction)
+}
+
+func TestMergeBumpBranches(t *testing.T) {
+	t.Parallel()
+	a := mpHashA(t)
+	b := mpHashB(t)
+
+	t.Run("same-pointer", func(t *testing.T) {
+		t.Parallel()
+		bf := NewBeef()
+		bump := singleLeafPath(5, a)
+		first := bf.MergeBump(bump)
+		second := bf.MergeBump(bump)
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("incoming-root-error", func(t *testing.T) {
+		t.Parallel()
+		bf := NewBeef()
+		bf.MergeBump(singleLeafPath(5, a))
+		assert.Equal(t, -1, bf.MergeBump(brokenTwoLevelPath(5, a)))
+	})
+
+	t.Run("existing-root-error", func(t *testing.T) {
+		t.Parallel()
+		bf := NewBeef()
+		bf.MergeBump(brokenTwoLevelPath(5, a))
+		assert.Equal(t, -1, bf.MergeBump(singleLeafPath(5, b)))
+	})
+}
+
+func TestMakeTxidOnlyBranches(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, NewBeef().MakeTxidOnly(nil))
+	assert.Nil(t, NewBeef().MakeTxidOnly(mpHashA(t)))
+
+	child := simpleFundedChild(t)
+	b, err := NewBeefFromTransaction(child)
+	require.NoError(t, err)
+	txid := child.TxID()
+
+	first := b.MakeTxidOnly(txid)
+	require.NotNil(t, first)
+	assert.Equal(t, TxIDOnly, first.DataFormat)
+	// Calling again returns the already-converted entry.
+	second := b.MakeTxidOnly(txid)
+	assert.Equal(t, first, second)
+}
+
+func TestMergeRawTxErrors(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+
+	_, err := b.MergeRawTx([]byte{0x01, 0x02}, nil)
+	require.Error(t, err)
+
+	badIndex := 99
+	_, err = b.MergeRawTx(minimalTxBytes(), &badIndex)
+	require.Error(t, err)
+}
+
+func TestMergeNilInputs(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+	assert.Nil(t, b.MergeTxidOnly(nil))
+
+	_, err := b.MergeBeefTx(nil)
+	require.Error(t, err)
+	_, err = b.MergeBeefTx(&BeefTx{DataFormat: RawTx})
+	require.Error(t, err)
+	_, err = b.MergeBeefTxWithTxid(mpHashA(t), nil)
+	require.Error(t, err)
+}
+
+func TestMergeBeefWithBumps(t *testing.T) {
+	t.Parallel()
+	other := NewBeef()
+	other.MergeBump(singleLeafPath(7, mpHashA(t)))
+
+	b := NewBeef()
+	require.NoError(t, b.MergeBeef(other))
+	require.Len(t, b.BUMPs, 1)
+}
+
+func TestBeefVerifyInvalidGraph(t *testing.T) {
+	t.Parallel()
+	child := NewTransaction()
+	child.AddInput(&TransactionInput{SourceTXID: mpHashA(t), SourceTxOutIndex: 0, SequenceNumber: DefaultSequenceNumber})
+	child.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	b := NewBeef()
+	b.Transactions[*child.TxID()] = &BeefTx{DataFormat: RawTx, Transaction: child}
+
+	ok, err := b.Verify(context.Background(), &mockChainTracker{validResult: true}, false)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// provedBeef builds a valid single-transaction BEEF whose transaction is proven
+// by a one-leaf merkle path, so verifyValid computes a real root.
+func provedBeef(t *testing.T) *Beef {
+	t.Helper()
+	tx := NewTransaction()
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+	txid := tx.TxID()
+	truthy := true
+	mp := &MerklePath{
+		BlockHeight: 800000,
+		Path:        [][]*PathElement{{{Offset: 0, Hash: txid, Txid: &truthy}}},
+	}
+	tx.MerklePath = mp
+	b := NewBeef()
+	b.BUMPs = []*MerklePath{mp}
+	b.Transactions[*txid] = &BeefTx{DataFormat: RawTxAndBumpIndex, Transaction: tx, BumpIndex: 0}
+	return b
+}
+
+func TestBeefVerifyProvenRootRejected(t *testing.T) {
+	t.Parallel()
+	b := provedBeef(t)
+	ok, err := b.Verify(context.Background(), &mockChainTracker{validResult: false}, false)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestBeefVerifyProvenRootAccepted(t *testing.T) {
+	t.Parallel()
+	b := provedBeef(t)
+	ok, err := b.Verify(context.Background(), &mockChainTracker{validResult: true}, false)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestBeefToLogStringWithProof(t *testing.T) {
+	t.Parallel()
+	b := provedBeef(t)
+	log := b.ToLogString()
+	assert.Contains(t, log, "BUMP")
+	assert.Contains(t, log, "bumpIndex")
+}
+
+func TestValidateTransactionsNotValid(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{SourceTXID: mpHashA(t), SourceTxOutIndex: 0, SequenceNumber: DefaultSequenceNumber})
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	b := NewBeef()
+	// Invalid bump index and an input to an unproven txid-only source.
+	b.Transactions[*tx.TxID()] = &BeefTx{DataFormat: RawTxAndBumpIndex, Transaction: tx, BumpIndex: 99}
+	b.Transactions[*mpHashA(t)] = &BeefTx{DataFormat: TxIDOnly, KnownTxID: mpHashA(t)}
+
+	result := b.ValidateTransactions()
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.NotValid)
+}
+
+func TestBeefBytesSerializationErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("txidonly-nil-known", func(t *testing.T) {
+		t.Parallel()
+		b := NewBeef()
+		b.Transactions[chainhash.Hash{}] = &BeefTx{DataFormat: TxIDOnly, KnownTxID: nil}
+		_, err := b.Bytes()
+		require.Error(t, err)
+	})
+
+	t.Run("rawtx-nil-transaction", func(t *testing.T) {
+		t.Parallel()
+		b := NewBeef()
+		b.Transactions[chainhash.Hash{}] = &BeefTx{DataFormat: RawTx, Transaction: nil}
+		_, err := b.Bytes()
+		require.Error(t, err)
+	})
+}
+
+func TestBeefTxidOnlyConversion(t *testing.T) {
+	t.Parallel()
+	child := simpleFundedChild(t)
+	b, err := NewBeefFromTransaction(child)
+	require.NoError(t, err)
+	// Add an explicit TxIDOnly entry too.
+	b.Transactions[*mpHashA(t)] = &BeefTx{DataFormat: TxIDOnly, KnownTxID: mpHashA(t)}
+
+	c, err := b.TxidOnly()
+	require.NoError(t, err)
+	for _, tx := range c.Transactions {
+		assert.Equal(t, TxIDOnly, tx.DataFormat)
+		require.NotNil(t, tx.KnownTxID)
+	}
+}
+
+func TestMergeWouldNotChange(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+	existing := &BeefTx{DataFormat: RawTx, Transaction: NewTransaction()}
+
+	// Input carrying a source transaction but no SourceTXID to reason about.
+	nilSourceID := NewTransaction()
+	nilSourceID.AddInput(&TransactionInput{SourceTransaction: NewTransaction(), SequenceNumber: DefaultSequenceNumber})
+	assert.False(t, b.mergeWouldNotChange(existing, nilSourceID))
+
+	// Input whose source is not present in the beef as a raw transaction.
+	unknownSource := NewTransaction()
+	unknownSource.AddInput(&TransactionInput{
+		SourceTXID:        mpHashA(t),
+		SourceTransaction: NewTransaction(),
+		SequenceNumber:    DefaultSequenceNumber,
+	})
+	assert.False(t, b.mergeWouldNotChange(existing, unknownSource))
+}
+
+func TestTrimUnreferencedBumpsEmpty(t *testing.T) {
+	t.Parallel()
+	b := NewBeef()
+	// No bumps -> trimming is a no-op early return.
+	b.TrimknownTxIDs(nil)
+	assert.Empty(t, b.BUMPs)
+}
+
+func TestTrimUnreferencedBumpsMixedFormats(t *testing.T) {
+	t.Parallel()
+	rawTx := NewTransaction()
+	rawTx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+	rawTxID := rawTx.TxID()
+	known := mpHashA(t)
+	truthy := true
+
+	bump0 := &MerklePath{BlockHeight: 1, Path: [][]*PathElement{{{Offset: 0, Hash: rawTxID, Txid: &truthy}}}}
+	bump1 := &MerklePath{BlockHeight: 2, Path: [][]*PathElement{{{Offset: 0, Hash: known, Txid: &truthy}}}}
+	bump2 := &MerklePath{BlockHeight: 3, Path: [][]*PathElement{{{Offset: 0, Hash: mpHashB(t), Txid: &truthy}}}}
+
+	b := NewBeef()
+	b.BUMPs = []*MerklePath{bump0, bump1, bump2}
+	b.Transactions[*rawTxID] = &BeefTx{DataFormat: RawTx, Transaction: rawTx}
+	b.Transactions[*known] = &BeefTx{DataFormat: TxIDOnly, KnownTxID: known}
+
+	// Nothing is deleted (empty known-list), but bump2 is referenced by no
+	// remaining transaction and is trimmed.
+	b.TrimknownTxIDs(nil)
+	assert.Len(t, b.BUMPs, 2)
+}
+
+func TestTrimUnreferencedBumps(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+	txid := tx.TxID()
+	truthy := true
+
+	mp0 := &MerklePath{BlockHeight: 1, Path: [][]*PathElement{{{Offset: 0, Hash: txid, Txid: &truthy}}}}
+	known := mpHashB(t)
+	mp1 := &MerklePath{BlockHeight: 2, Path: [][]*PathElement{{{Offset: 0, Hash: known, Txid: &truthy}}}}
+
+	b := NewBeef()
+	b.BUMPs = []*MerklePath{mp0, mp1}
+	b.Transactions[*txid] = &BeefTx{DataFormat: RawTxAndBumpIndex, Transaction: tx, BumpIndex: 0}
+	b.Transactions[*known] = &BeefTx{DataFormat: TxIDOnly, KnownTxID: known}
+
+	b.TrimknownTxIDs([]string{known.String()})
+
+	// The txid-only entry and its now-unreferenced bump are trimmed.
+	assert.Len(t, b.BUMPs, 1)
+	_, stillThere := b.Transactions[*known]
+	assert.False(t, stillThere)
+}

--- a/transaction/io_extra_test.go
+++ b/transaction/io_extra_test.go
@@ -1,0 +1,135 @@
+package transaction
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+)
+
+func TestOutputReadFromRoundTrip(t *testing.T) {
+	t.Parallel()
+	ls := script.NewFromBytes([]byte{0x51, 0x52, 0x53})
+	out := &TransactionOutput{Satoshis: 4242, LockingScript: ls}
+
+	var got TransactionOutput
+	n, err := got.ReadFrom(bytes.NewReader(out.Bytes()))
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(out.Bytes())), n)
+	assert.Equal(t, uint64(4242), got.Satoshis)
+	assert.Equal(t, []byte(*ls), []byte(*got.LockingScript))
+}
+
+func TestOutputReadFromTruncated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "satoshis-short", data: []byte{0x01, 0x02, 0x03}},
+		{name: "script-len-eof", data: make([]byte, 8)},
+		{name: "script-bytes-short", data: append(make([]byte, 8), 0x05)}, // says 5 script bytes, none present
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out TransactionOutput
+			_, err := out.ReadFrom(bytes.NewReader(tc.data))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestOutputWriteToError(t *testing.T) {
+	t.Parallel()
+	out := &TransactionOutput{Satoshis: 1, LockingScript: script.NewFromBytes([]byte{0x51})}
+	var total int64
+	err := out.writeTo(&limitWriter{limit: 0}, make([]byte, 9), &total)
+	require.ErrorIs(t, err, errLimitWrite)
+}
+
+func TestInputReadFromTruncated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "index-eof", data: make([]byte, 32)},                  // txid only
+		{name: "scriptlen-eof", data: make([]byte, 36)},              // txid + index
+		{name: "sequence-eof", data: append(make([]byte, 36), 0x00)}, // + empty script varint
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var in TransactionInput
+			_, err := in.ReadFrom(bytes.NewReader(tc.data))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestInputReadFromExtendedTruncated(t *testing.T) {
+	t.Parallel()
+	base := func() []byte {
+		b := make([]byte, 0, 41)
+		b = append(b, make([]byte, 32)...)    // txid
+		b = append(b, 0x00, 0x00, 0x00, 0x00) // index
+		b = append(b, 0x00)                   // empty script
+		b = append(b, 0x00, 0x00, 0x00, 0x00) // sequence
+		return b
+	}
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "prev-satoshis-eof", data: base()},
+		{name: "src-scriptlen-eof", data: append(base(), make([]byte, 8)...)},
+		{name: "src-script-short", data: append(append(base(), make([]byte, 8)...), 0xFE, 0xFF, 0xFF, 0xFF, 0xFF)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var in TransactionInput
+			_, err := in.ReadFromExtended(bytes.NewReader(tc.data))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestInputWriteToErrors(t *testing.T) {
+	t.Parallel()
+
+	// Each subtest must own its scratch buffer: writeTo writes into the caller-supplied
+	// scratch slice, so sharing one across parallel subtests is a data race.
+	t.Run("index-write", func(t *testing.T) {
+		t.Parallel()
+		in := &TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: 1}
+		var total int64
+		err := in.writeTo(&limitWriter{limit: 32}, make([]byte, 9), &total)
+		require.ErrorIs(t, err, errLimitWrite)
+	})
+
+	t.Run("empty-script-write", func(t *testing.T) {
+		t.Parallel()
+		in := &TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: 1}
+		var total int64
+		err := in.writeTo(&limitWriter{limit: 36}, make([]byte, 9), &total)
+		require.ErrorIs(t, err, errLimitWrite)
+	})
+
+	t.Run("script-body-write", func(t *testing.T) {
+		t.Parallel()
+		in := &TransactionInput{
+			SourceTXID:      &chainhash.Hash{},
+			UnlockingScript: script.NewFromBytes([]byte{0x51, 0x52, 0x53}),
+			SequenceNumber:  1,
+		}
+		var total int64
+		err := in.writeTo(&limitWriter{limit: 37}, make([]byte, 9), &total)
+		require.ErrorIs(t, err, errLimitWrite)
+	})
+}

--- a/transaction/merklepath_extra_test.go
+++ b/transaction/merklepath_extra_test.go
@@ -1,0 +1,181 @@
+package transaction
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+)
+
+func mpHashA(t *testing.T) *chainhash.Hash {
+	t.Helper()
+	h, err := chainhash.NewHashFromHex("1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+	return h
+}
+
+func mpHashB(t *testing.T) *chainhash.Hash {
+	t.Helper()
+	h, err := chainhash.NewHashFromHex("2222222222222222222222222222222222222222222222222222222222222222")
+	require.NoError(t, err)
+	return h
+}
+
+// singleLeafPath builds a one-level, one-leaf MerklePath whose root equals the
+// leaf hash.
+func singleLeafPath(height uint32, hash *chainhash.Hash) *MerklePath {
+	return &MerklePath{
+		BlockHeight: height,
+		Path:        [][]*PathElement{{{Offset: 0, Hash: hash}}},
+	}
+}
+
+// brokenTwoLevelPath has a leaf at level 0 but an empty level 1, so ComputeRoot
+// cannot find the sibling it needs.
+func brokenTwoLevelPath(height uint32, hash *chainhash.Hash) *MerklePath {
+	return &MerklePath{
+		BlockHeight: height,
+		Path:        [][]*PathElement{{{Offset: 0, Hash: hash}}, {}},
+	}
+}
+
+func TestNewMerklePathFromReaderTruncated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "index-eof", data: nil},
+		{name: "tree-height-eof", data: []byte{0x00}},
+		{name: "leaf-count-overflow", data: []byte{0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+		{name: "offset-eof", data: []byte{0x00, 0x01, 0x01, 0xFF, 0x00}},
+		{name: "flags-eof", data: []byte{0x00, 0x01, 0x01, 0xFD, 0x00, 0x00}},
+		{name: "hash-eof", data: []byte{0x00, 0x01, 0x01, 0x00, 0x00}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewMerklePathFromReader(bytes.NewReader(tc.data))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestComputeRootHexInvalidTxid(t *testing.T) {
+	t.Parallel()
+	mp := singleLeafPath(100, mpHashA(t))
+	bad := "not-hex"
+	_, err := mp.ComputeRootHex(&bad)
+	require.Error(t, err)
+}
+
+func TestComputeRootSingleLeaf(t *testing.T) {
+	t.Parallel()
+	a := mpHashA(t)
+	mp := singleLeafPath(100, a)
+	root, err := mp.ComputeRoot(nil)
+	require.NoError(t, err)
+	assert.True(t, root.Equal(*a))
+}
+
+func TestComputeRootMissingHash(t *testing.T) {
+	t.Parallel()
+	a := mpHashA(t)
+	b := mpHashB(t)
+	// Two leaves at level 0 and an empty level 1 forces the height-1 lookup to
+	// recurse and fail, exercising GetOffsetLeaf's nil returns.
+	mp := &MerklePath{
+		BlockHeight: 100,
+		Path: [][]*PathElement{
+			{{Offset: 0, Hash: a}, {Offset: 1, Hash: b}},
+			{},
+		},
+	}
+	_, err := mp.ComputeRoot(a)
+	require.Error(t, err)
+}
+
+func TestMerklePathCombineErrors(t *testing.T) {
+	t.Parallel()
+	a := mpHashA(t)
+	b := mpHashB(t)
+
+	t.Run("different-heights", func(t *testing.T) {
+		t.Parallel()
+		m := singleLeafPath(1, a)
+		other := singleLeafPath(2, a)
+		err := m.Combine(other)
+		require.ErrorContains(t, err, "different block heights")
+	})
+
+	t.Run("root1-error", func(t *testing.T) {
+		t.Parallel()
+		m := brokenTwoLevelPath(5, a)
+		other := singleLeafPath(5, a)
+		err := m.Combine(other)
+		require.Error(t, err)
+	})
+
+	t.Run("root2-error", func(t *testing.T) {
+		t.Parallel()
+		m := singleLeafPath(5, a)
+		other := brokenTwoLevelPath(5, a)
+		err := m.Combine(other)
+		require.Error(t, err)
+	})
+
+	t.Run("different-roots", func(t *testing.T) {
+		t.Parallel()
+		m := singleLeafPath(5, a)
+		other := singleLeafPath(5, b)
+		err := m.Combine(other)
+		require.ErrorContains(t, err, "different roots")
+	})
+}
+
+func TestMerklePathVerifyComputeRootError(t *testing.T) {
+	t.Parallel()
+	a := mpHashA(t)
+	b := mpHashB(t)
+	// Two leaves so ComputeRoot must actually search for the txid, which is
+	// absent -> error.
+	mp := &MerklePath{
+		BlockHeight: 100,
+		Path:        [][]*PathElement{{{Offset: 0, Hash: a}, {Offset: 1, Hash: b}}},
+	}
+	wrong, err := chainhash.NewHashFromHex("3333333333333333333333333333333333333333333333333333333333333333")
+	require.NoError(t, err)
+
+	ok, err := mp.Verify(context.Background(), wrong, &mockChainTracker{validResult: true})
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestFindLeafByOffsetOutOfRange(t *testing.T) {
+	t.Parallel()
+	mp := singleLeafPath(1, mpHashA(t))
+	assert.Nil(t, mp.FindLeafByOffset(-1, 0))
+	assert.Nil(t, mp.FindLeafByOffset(5, 0))
+}
+
+func TestComputeMissingHashesTooFewLevels(t *testing.T) {
+	t.Parallel()
+	mp := singleLeafPath(1, mpHashA(t))
+	// Single-level paths return early without modification.
+	mp.ComputeMissingHashes()
+	assert.Len(t, mp.Path, 1)
+}
+
+func TestMerkleTreeParentStrErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := MerkleTreeParentStr("zz", "00")
+	require.Error(t, err)
+
+	_, err = MerkleTreeParentStr("00", "zz")
+	require.Error(t, err)
+}

--- a/transaction/misc_extra_test.go
+++ b/transaction/misc_extra_test.go
@@ -1,0 +1,175 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+)
+
+const validTxidHex = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestOutpointFromStringBadIndex(t *testing.T) {
+	t.Parallel()
+	_, err := OutpointFromString(validTxidHex + ".notanumber")
+	require.Error(t, err)
+}
+
+func TestInscribeWithEnrichedOpReturn(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	ia := &script.InscriptionArgs{
+		LockingScript: &script.Script{},
+		ContentType:   "text/plain",
+		Data:          []byte("hello"),
+		EnrichedArgs: &script.EnrichedInscriptionArgs{
+			OpReturnData: [][]byte{[]byte("a"), []byte("b")},
+		},
+	}
+	require.NoError(t, tx.Inscribe(ia))
+	require.Len(t, tx.Outputs, 1)
+}
+
+func TestInscribeSpecificOrdinalAccumulates(t *testing.T) {
+	t.Parallel()
+	src := NewTransaction()
+	src.AddOutput(&TransactionOutput{Satoshis: 5000, LockingScript: &script.Script{}})
+	tx := NewTransaction()
+	tx.AddInputFromTx(src, 0, nil)
+
+	ia := &script.InscriptionArgs{
+		LockingScript: &script.Script{},
+		ContentType:   "text/plain",
+		Data:          []byte("data"),
+	}
+	require.NoError(t, tx.InscribeSpecificOrdinal(ia, 1, 100, &script.Script{}))
+	// One output for the leading satoshis, one for the inscription.
+	require.Len(t, tx.Outputs, 2)
+	assert.Equal(t, uint64(5100), tx.Outputs[0].Satoshis)
+}
+
+func TestInscribeSpecificOrdinalRangeError(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	ia := &script.InscriptionArgs{
+		LockingScript: &script.Script{},
+		ContentType:   "text/plain",
+		Data:          []byte("data"),
+	}
+	err := tx.InscribeSpecificOrdinal(ia, 5, 0, &script.Script{})
+	require.ErrorIs(t, err, ErrOutputNoExist)
+}
+
+func TestFeeComputeError(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	err := tx.Fee(errFeeModel{}, ChangeDistributionEqual)
+	require.Error(t, err)
+}
+
+func TestFeeMissingPreviousTx(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+	err := tx.Fee(&fixedFeeModel{fee: 0}, ChangeDistributionEqual)
+	require.ErrorIs(t, err, ErrEmptyPreviousTx)
+}
+
+func TestFeeRemovesChangeWhenTooSmall(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	in := &TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber}
+	in.SetSourceTxOutput(&TransactionOutput{Satoshis: 1000, LockingScript: &script.Script{}})
+	tx.AddInput(in)
+	tx.AddOutput(&TransactionOutput{Satoshis: 0, LockingScript: &script.Script{}})
+	tx.AddOutput(&TransactionOutput{LockingScript: &script.Script{}, Change: true})
+	tx.AddOutput(&TransactionOutput{LockingScript: &script.Script{}, Change: true})
+
+	// change (1000 - 0 - 999 = 1) is less than the 2 change outputs, so they are
+	// dropped, leaving the miners the remainder.
+	require.NoError(t, tx.Fee(&fixedFeeModel{fee: 999}, ChangeDistributionEqual))
+	require.Len(t, tx.Outputs, 1)
+	assert.False(t, tx.Outputs[0].Change)
+}
+
+func TestAddInputFromErrors(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+
+	// Invalid locking script hex.
+	err := tx.AddInputFrom(validTxidHex, 0, "zz", 100, nil)
+	require.Error(t, err)
+
+	// Invalid source txid hex.
+	err = tx.AddInputFrom("nothex", 0, "", 100, nil)
+	require.Error(t, err)
+}
+
+func TestTransactionMarshalJSONNil(t *testing.T) {
+	t.Parallel()
+	var tx *Transaction
+	_, err := tx.MarshalJSON()
+	require.ErrorIs(t, err, ErrTxNil)
+}
+
+func TestTransactionUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid-json", func(t *testing.T) {
+		t.Parallel()
+		var tx Transaction
+		require.Error(t, tx.UnmarshalJSON([]byte("not json")))
+	})
+
+	t.Run("invalid-hex", func(t *testing.T) {
+		t.Parallel()
+		var tx Transaction
+		require.Error(t, tx.UnmarshalJSON([]byte(`{"hex":"zz"}`)))
+	})
+
+	t.Run("no-hex-uses-fields", func(t *testing.T) {
+		t.Parallel()
+		var tx Transaction
+		require.NoError(t, tx.UnmarshalJSON([]byte(`{"hex":"","lockTime":5,"version":2}`)))
+		assert.Equal(t, uint32(5), tx.LockTime)
+		assert.Equal(t, uint32(2), tx.Version)
+	})
+}
+
+func TestInputUnmarshalJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid-json", func(t *testing.T) {
+		t.Parallel()
+		var in TransactionInput
+		require.Error(t, in.UnmarshalJSON([]byte("nope")))
+	})
+
+	t.Run("invalid-txid", func(t *testing.T) {
+		t.Parallel()
+		var in TransactionInput
+		require.Error(t, in.UnmarshalJSON([]byte(`{"txid":"nothex","unlockingScript":""}`)))
+	})
+
+	t.Run("invalid-script", func(t *testing.T) {
+		t.Parallel()
+		var in TransactionInput
+		require.Error(t, in.UnmarshalJSON([]byte(`{"txid":"`+validTxidHex+`","unlockingScript":"zz"}`)))
+	})
+}
+
+func TestOutputUnmarshalJSONError(t *testing.T) {
+	t.Parallel()
+	var out TransactionOutput
+	require.Error(t, out.UnmarshalJSON([]byte("not json")))
+	require.Error(t, out.UnmarshalJSON([]byte(`{"lockingScript":"zz"}`)))
+}
+
+func TestPayToAddressInvalid(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	require.Error(t, tx.PayToAddress("not-a-valid-address", 100))
+}

--- a/transaction/template/pushdrop/pushdrop_extra_test.go
+++ b/transaction/template/pushdrop/pushdrop_extra_test.go
@@ -1,0 +1,95 @@
+package pushdrop_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/pushdrop"
+	"github.com/bsv-blockchain/go-sdk/util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func TestDecodeReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	t.Run("too-few-chunks", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, pushdrop.Decode(&script.Script{}))
+	})
+
+	t.Run("not-a-pushdrop", func(t *testing.T) {
+		t.Parallel()
+		s := &script.Script{}
+		require.NoError(t, s.AppendPushData([]byte{0x01, 0x02, 0x03}))
+		require.NoError(t, s.AppendPushData([]byte{0x04, 0x05, 0x06}))
+		assert.Nil(t, pushdrop.Decode(s))
+	})
+}
+
+func TestCreateMinimallyEncodedScriptChunkZeroCases(t *testing.T) {
+	t.Parallel()
+
+	empty := pushdrop.CreateMinimallyEncodedScriptChunk(nil)
+	assert.Equal(t, script.Op0, empty.Op)
+
+	single := pushdrop.CreateMinimallyEncodedScriptChunk([]byte{0})
+	assert.Equal(t, script.Op0, single.Op)
+}
+
+func TestUnlockWithOptions(t *testing.T) {
+	t.Parallel()
+	p := &pushdrop.PushDrop{}
+	sats := uint64(1234)
+	ls := &script.Script{}
+	unlocker := p.Unlock(
+		context.Background(),
+		wallet.Protocol{SecurityLevel: 0, Protocol: "testing"},
+		"key",
+		wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+		wallet.SignOutputsAll,
+		false,
+		pushdrop.UnlockOptions{SourceSatoshis: &sats, LockingScript: ls},
+	)
+	require.NotNil(t, unlocker)
+	assert.Equal(t, uint32(73), unlocker.EstimateLength())
+}
+
+func TestLockAfterPosition(t *testing.T) {
+	ctx := context.Background()
+	testWallet := createTestWallet(t)
+	p := &pushdrop.PushDrop{Wallet: testWallet, Originator: "test"}
+
+	fields := [][]byte{[]byte("a"), []byte("b")}
+	protocolID := wallet.Protocol{SecurityLevel: 0, Protocol: "testing"}
+	counterparty := wallet.Counterparty{Type: wallet.CounterpartyTypeSelf}
+
+	lockingScript, err := p.Lock(
+		ctx,
+		fields,
+		protocolID,
+		"test-key",
+		counterparty,
+		false,
+		false,
+		pushdrop.LockAfter,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lockingScript)
+
+	// Confirm the same public key is retrievable, proving the lock-after script
+	// was assembled.
+	expected, err := testWallet.GetPublicKey(ctx, wallet.GetPublicKeyArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID:   protocolID,
+			KeyID:        "test-key",
+			Counterparty: counterparty,
+		},
+		ForSelf: util.BoolPtr(false),
+	}, "test")
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+}

--- a/transaction/transaction_extra_test.go
+++ b/transaction/transaction_extra_test.go
@@ -1,0 +1,400 @@
+package transaction
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	sighash "github.com/bsv-blockchain/go-sdk/transaction/sighash"
+)
+
+// errUnlockTemplate is an UnlockingScriptTemplate whose Sign always fails, used
+// to drive the error paths of Transaction.Sign / SignUnsigned.
+type errUnlockTemplate struct{}
+
+func (errUnlockTemplate) Sign(*Transaction, uint32) (*script.Script, error) {
+	return nil, errors.New("template sign failed")
+}
+
+func (errUnlockTemplate) EstimateLength(*Transaction, uint32) uint32 { return 0 }
+
+// errFeeModel is a FeeModel whose ComputeFee always fails.
+type errFeeModel struct{}
+
+func (errFeeModel) ComputeFee(*Transaction) (uint64, error) {
+	return 0, errors.New("compute fee failed")
+}
+
+// errLimitWrite is returned by limitWriter once its byte budget is exhausted.
+var errLimitWrite = errors.New("limitWriter budget exhausted")
+
+// limitWriter accepts limit total bytes and then fails, returning any partial
+// write alongside the error so streaming error paths can be exercised.
+type limitWriter struct {
+	limit   int
+	written int
+}
+
+func (lw *limitWriter) Write(p []byte) (int, error) {
+	remaining := lw.limit - lw.written
+	if remaining <= 0 {
+		return 0, errLimitWrite
+	}
+	if len(p) > remaining {
+		lw.written += remaining
+		return remaining, errLimitWrite
+	}
+	lw.written += len(p)
+	return len(p), nil
+}
+
+func TestNewTransactionFromHexInvalid(t *testing.T) {
+	t.Parallel()
+	_, err := NewTransactionFromHex("zzzz")
+	require.Error(t, err)
+}
+
+func TestNewTransactionFromBytesTrailingData(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+	raw := tx.Bytes()
+	// Appending a trailing byte makes used != len(b).
+	_, err := NewTransactionFromBytes(append(raw, 0x00))
+	require.ErrorIs(t, err, ErrNLockTimeLength)
+}
+
+func TestTransactionReadFromTruncated(t *testing.T) {
+	t.Parallel()
+	ver := []byte{0x01, 0x00, 0x00, 0x00}
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "no-output-count", data: append(append([]byte{}, ver...), 0x00)},
+		{name: "no-locktime-empty-tx", data: append(append([]byte{}, ver...), 0x00, 0x00)},
+		{
+			name: "extended-marker-then-eof",
+			data: append(append([]byte{}, ver...), 0x00, 0x00, 0x00, 0x00, 0x00, 0xEF),
+		},
+		{
+			name: "input-count-overflow",
+			data: append(append([]byte{}, ver...), 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewTransactionFromBytes(tc.data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestTransactionReadFromInputParseError(t *testing.T) {
+	t.Parallel()
+	// version + inputCount(1) + 32 txid + 4 index + varint 0xFE FFFFFFFF (huge
+	// script length). The count guard passes (41 bytes remain) but the per-input
+	// script guard rejects the impossible length.
+	data := make([]byte, 0, 46)
+	data = append(data, 0x01, 0x00, 0x00, 0x00, 0x01)
+	data = append(data, make([]byte, 32)...)    // txid
+	data = append(data, 0x00, 0x00, 0x00, 0x00) // index
+	data = append(data, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF)
+	_, err := NewTransactionFromBytes(data)
+	require.Error(t, err)
+}
+
+func validInputBytes() []byte {
+	b := make([]byte, 0, 41)
+	b = append(b, make([]byte, 32)...)    // txid
+	b = append(b, 0x00, 0x00, 0x00, 0x00) // index
+	b = append(b, 0x00)                   // empty unlocking script
+	b = append(b, 0xFF, 0xFF, 0xFF, 0xFF) // sequence
+	return b
+}
+
+func TestTransactionReadFromOutputStageErrors(t *testing.T) {
+	t.Parallel()
+	ver := []byte{0x01, 0x00, 0x00, 0x00}
+	in := validInputBytes()
+
+	base := func() []byte {
+		b := append([]byte{}, ver...)
+		b = append(b, 0x01) // inputCount = 1
+		b = append(b, in...)
+		return b
+	}
+
+	t.Run("output-count-eof", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewTransactionFromBytes(base())
+		require.Error(t, err)
+	})
+
+	t.Run("output-count-overflow", func(t *testing.T) {
+		t.Parallel()
+		b := base()
+		b = append(b, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)
+		_, err := NewTransactionFromBytes(b)
+		require.Error(t, err)
+	})
+
+	t.Run("output-parse-error", func(t *testing.T) {
+		t.Parallel()
+		b := base()
+		b = append(b, 0x01)                         // outputCount = 1
+		b = append(b, make([]byte, 8)...)           // satoshis
+		b = append(b, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF) // huge script length
+		_, err := NewTransactionFromBytes(b)
+		require.Error(t, err)
+	})
+
+	t.Run("locktime-eof", func(t *testing.T) {
+		t.Parallel()
+		b := base()
+		b = append(b, 0x01)               // outputCount = 1
+		b = append(b, make([]byte, 8)...) // satoshis
+		b = append(b, 0x00)               // empty locking script
+		// no locktime bytes -> EOF
+		_, err := NewTransactionFromBytes(b)
+		require.Error(t, err)
+	})
+}
+
+func TestTransactionsReadFromErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("count-eof", func(t *testing.T) {
+		t.Parallel()
+		var tt Transactions
+		_, err := tt.ReadFrom(bytes.NewReader(nil))
+		require.Error(t, err)
+	})
+
+	t.Run("count-overflow", func(t *testing.T) {
+		t.Parallel()
+		var tt Transactions
+		data := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+		_, err := tt.ReadFrom(bytes.NewReader(data))
+		require.Error(t, err)
+	})
+
+	t.Run("inner-tx-error", func(t *testing.T) {
+		t.Parallel()
+		var tt Transactions
+		data := make([]byte, 0, 14)
+		data = append(data, 0x01)                   // txCount = 1
+		data = append(data, 0x01, 0x00, 0x00, 0x00) // version
+		data = append(data, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)
+		_, err := tt.ReadFrom(bytes.NewReader(data))
+		require.Error(t, err)
+	})
+}
+
+func TestTransactionsReadFromRoundTrip(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddOutput(&TransactionOutput{Satoshis: 7, LockingScript: &script.Script{}})
+
+	buf := new(bytes.Buffer)
+	buf.Write([]byte{0x01}) // one transaction
+	buf.Write(tx.Bytes())
+
+	var tt Transactions
+	_, err := tt.ReadFrom(buf)
+	require.NoError(t, err)
+	require.Len(t, tt, 1)
+	assert.Equal(t, uint64(7), tt[0].Outputs[0].Satoshis)
+}
+
+func TestTransactionIsCoinbaseFalseCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-inputs", func(t *testing.T) {
+		t.Parallel()
+		tx := NewTransaction()
+		assert.False(t, tx.IsCoinbase())
+	})
+
+	t.Run("nonzero-source-txid", func(t *testing.T) {
+		t.Parallel()
+		hash, _ := chainhash.NewHashFromHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
+		tx := NewTransaction()
+		tx.AddInput(&TransactionInput{SourceTXID: hash, SourceTxOutIndex: 0, SequenceNumber: 0})
+		assert.False(t, tx.IsCoinbase())
+	})
+
+	t.Run("zero-txid-but-not-max-index-or-seq", func(t *testing.T) {
+		t.Parallel()
+		tx := NewTransaction()
+		tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SourceTxOutIndex: 0, SequenceNumber: 0})
+		assert.False(t, tx.IsCoinbase())
+	})
+}
+
+func TestTransactionEFWithMissingSourceOutput(t *testing.T) {
+	t.Parallel()
+	// SourceTransaction is set but its output index is out of range and no
+	// direct sourceOutput is supplied, so SourceTxOutput() returns nil while
+	// EF()'s guard still passes -- exercising the zero-source-output serializer.
+	src := NewTransaction() // no outputs
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{
+		SourceTXID:        src.TxID(),
+		SourceTxOutIndex:  5,
+		SourceTransaction: src,
+		SequenceNumber:    DefaultSequenceNumber,
+	})
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	ef, err := tx.EF()
+	require.NoError(t, err)
+	require.NotEmpty(t, ef)
+}
+
+func TestTransactionWriteToOutputCountError(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	// 4 (version) + 1 (input count) + 41 (input) = 46 bytes written before the
+	// output-count varint, which then fails.
+	_, err := tx.WriteTo(&limitWriter{limit: 46})
+	require.ErrorIs(t, err, errLimitWrite)
+}
+
+func TestTransactionSignSkipsNilTemplate(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+	require.NoError(t, tx.Sign())
+}
+
+func TestTransactionSignTemplateError(t *testing.T) {
+	t.Parallel()
+
+	build := func() *Transaction {
+		tx := NewTransaction()
+		tx.AddInput(&TransactionInput{
+			SourceTXID:              &chainhash.Hash{},
+			SequenceNumber:          DefaultSequenceNumber,
+			UnlockingScriptTemplate: errUnlockTemplate{},
+		})
+		tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+		return tx
+	}
+
+	require.Error(t, build().Sign())
+	require.Error(t, build().SignUnsigned())
+}
+
+func TestTransactionSignFeeNotComputed(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddOutput(&TransactionOutput{Satoshis: 0, LockingScript: &script.Script{}, Change: true})
+	require.Error(t, tx.Sign())
+	require.Error(t, tx.SignUnsigned())
+}
+
+func TestAtomicBEEFMissingSource(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	_, err := tx.AtomicBEEF(false)
+	require.Error(t, err)
+
+	// allowPartial skips the missing source rather than erroring.
+	partial, err := tx.AtomicBEEF(true)
+	require.NoError(t, err)
+	require.NotEmpty(t, partial)
+}
+
+func TestNewTransactionFromBEEFErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("atomic-hash-eof", func(t *testing.T) {
+		t.Parallel()
+		// hex.DecodeString keeps the length out of static analysis (io.ReadFull of
+		// the 32-byte hash fails long before the beef[36:] reslice is reached).
+		data, err := hex.DecodeString("01010101" + "00000000000000000000") // ATOMIC_BEEF + 10 bytes
+		require.NoError(t, err)
+		_, err = NewTransactionFromBEEF(data)
+		require.Error(t, err)
+	})
+
+	t.Run("atomic-body-invalid", func(t *testing.T) {
+		t.Parallel()
+		data := make([]byte, 0, 38)
+		data = append(data, le32(ATOMIC_BEEF)...)
+		data = append(data, make([]byte, 32)...) // hash
+		data = append(data, 0x00, 0x00)          // too-short body for readVersion
+		_, err := NewTransactionFromBEEF(data)
+		require.Error(t, err)
+	})
+
+	t.Run("unknown-version", func(t *testing.T) {
+		t.Parallel()
+		data, err := hex.DecodeString("00000000")
+		require.NoError(t, err)
+		_, err = NewTransactionFromBEEF(data)
+		require.Error(t, err)
+	})
+}
+
+func TestCalcInputSignatureHashLegacySingleOutOfRange(t *testing.T) {
+	t.Parallel()
+	// A single input with a source but no outputs, signed with SIGHASH_SINGLE
+	// (legacy, no FORKID) yields the defaultHex sentinel unchanged.
+	src := NewTransaction()
+	src.AddOutput(&TransactionOutput{Satoshis: 1000, LockingScript: &script.Script{}})
+	tx := NewTransaction()
+	tx.AddInputFromTx(src, 0, nil)
+
+	digest, err := tx.CalcInputSignatureHash(0, sighash.Single)
+	require.NoError(t, err)
+	assert.Equal(t, defaultHex, digest)
+}
+
+func TestCalcInputSignatureHashErrors(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	// Out-of-range input index, FORKID path.
+	_, err := tx.CalcInputSignatureHash(5, sighash.All|sighash.ForkID)
+	require.ErrorIs(t, err, ErrInputNoExist)
+
+	_, err = tx.CalcInputSignatureHashWithCache(5, sighash.All|sighash.ForkID, nil)
+	require.ErrorIs(t, err, ErrInputNoExist)
+}
+
+func TestCalcInputPreimageMissingSource(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	tx.AddInput(&TransactionInput{SourceTXID: &chainhash.Hash{}, SequenceNumber: DefaultSequenceNumber})
+	tx.AddOutput(&TransactionOutput{Satoshis: 1, LockingScript: &script.Script{}})
+
+	_, err := tx.CalcInputPreimage(0, sighash.All|sighash.ForkID)
+	require.ErrorIs(t, err, ErrEmptyPreviousTx)
+
+	_, err = tx.CalcInputPreimageLegacy(0, sighash.All)
+	require.ErrorIs(t, err, ErrEmptyPreviousTx)
+}
+
+func TestCalcInputPreimageLegacyNoInput(t *testing.T) {
+	t.Parallel()
+	tx := NewTransaction()
+	_, err := tx.CalcInputPreimageLegacy(3, sighash.All)
+	require.ErrorIs(t, err, ErrInputNoExist)
+}

--- a/util/bytestring_extra_test.go
+++ b/util/bytestring_extra_test.go
@@ -1,0 +1,35 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+)
+
+// TestByteStringUnmarshalJSONError covers the json.Unmarshal failure branch of
+// ByteString.UnmarshalJSON (bytestring.go:30-31), where the input is not a JSON
+// string.
+func TestByteStringUnmarshalJSONError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"number is not a string", "123"},
+		{"malformed json", "{"},
+		{"object is not a string", `{"a":1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var bs util.ByteString
+			err := bs.UnmarshalJSON([]byte(tt.input))
+			require.Error(t, err)
+		})
+	}
+}

--- a/util/reader_error_extra_test.go
+++ b/util/reader_error_extra_test.go
@@ -1,0 +1,199 @@
+package util_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+)
+
+// TestReaderReadVarIntOptionalError covers the varint-read failure branch of
+// ReadVarIntOptional (reader.go:87-88).
+func TestReaderReadVarIntOptionalError(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReader([]byte{})
+	v, err := r.ReadVarIntOptional()
+	require.Error(t, err)
+	require.Nil(t, v)
+}
+
+// TestReaderReadOptionalStringError covers the propagated-error branch of
+// ReadOptionalString (reader.go:137-138).
+func TestReaderReadOptionalStringError(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReader([]byte{})
+	s, err := r.ReadOptionalString()
+	require.Error(t, err)
+	require.Empty(t, s)
+}
+
+// TestReaderReadOptionalBytesLengthError covers the length-varint failure branch
+// of ReadOptionalBytes when neither the flag nor txid-length options are set
+// (reader.go:173-174).
+func TestReaderReadOptionalBytesLengthError(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReader([]byte{})
+	b, err := r.ReadOptionalBytes()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error reading length")
+	require.Nil(t, b)
+}
+
+// TestReaderReadOptionalUint32Errors covers both error branches of
+// ReadOptionalUint32: the varint-read failure (reader.go:185-186) and the
+// value-exceeds-uint32 guard (reader.go:192-193).
+func TestReaderReadOptionalUint32Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("varint read fails", func(t *testing.T) {
+		t.Parallel()
+
+		r := util.NewReader([]byte{})
+		v, err := r.ReadOptionalUint32()
+		require.Error(t, err)
+		require.Nil(t, v)
+	})
+
+	t.Run("value exceeds uint32 maximum", func(t *testing.T) {
+		t.Parallel()
+
+		// A value above MaxUint32 (but not the MaxUint64 sentinel) must error.
+		w := util.NewWriter()
+		w.WriteVarInt(uint64(math.MaxUint32) + 1)
+		r := util.NewReader(w.Buf)
+		v, err := r.ReadOptionalUint32()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds uint32 maximum")
+		require.Nil(t, v)
+	})
+}
+
+// TestReaderReadTxidSliceCountError covers the count-varint failure branch of
+// ReadTxidSlice (reader.go:213-214).
+func TestReaderReadTxidSliceCountError(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReader([]byte{})
+	result, err := r.ReadTxidSlice()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "slice txid count")
+	require.Nil(t, result)
+}
+
+// TestReaderReadStringSliceErrors covers the count-varint failure
+// (reader.go:238-239), the count-exceeds-int guard (reader.go:244-245), and the
+// per-element string read failure (reader.go:251-252).
+func TestReaderReadStringSliceErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("count varint fails", func(t *testing.T) {
+		t.Parallel()
+
+		r := util.NewReader([]byte{})
+		result, err := r.ReadStringSlice()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "slice string count")
+		require.Nil(t, result)
+	})
+
+	t.Run("count exceeds max int", func(t *testing.T) {
+		t.Parallel()
+
+		// MaxInt64 is >= math.MaxInt on 64-bit platforms but is not the
+		// MaxUint64 "nil" sentinel, so it trips the size guard.
+		w := util.NewWriter()
+		w.WriteVarInt(uint64(math.MaxInt64))
+		r := util.NewReader(w.Buf)
+		result, err := r.ReadStringSlice()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum int size")
+		require.Nil(t, result)
+	})
+
+	t.Run("element string read fails", func(t *testing.T) {
+		t.Parallel()
+
+		// count=1 followed by a string whose length prefix promises more bytes
+		// than are present.
+		w := util.NewWriter()
+		w.WriteVarInt(1)  // count
+		w.WriteVarInt(10) // string length with no following bytes
+		r := util.NewReader(w.Buf)
+		result, err := r.ReadStringSlice()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error reading string for slice")
+		require.Nil(t, result)
+	})
+}
+
+// TestReaderReadOptionalToHexErrors covers the length-varint failure
+// (reader.go:261-262) and the data-read failure (reader.go:268-269) branches of
+// ReadOptionalToHex.
+func TestReaderReadOptionalToHexErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("length varint fails", func(t *testing.T) {
+		t.Parallel()
+
+		r := util.NewReader([]byte{})
+		s, err := r.ReadOptionalToHex()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "data length for optional hex")
+		require.Empty(t, s)
+	})
+
+	t.Run("data bytes read fails", func(t *testing.T) {
+		t.Parallel()
+
+		w := util.NewWriter()
+		w.WriteVarInt(10) // claims 10 bytes but none follow
+		r := util.NewReader(w.Buf)
+		s, err := r.ReadOptionalToHex()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "data bytes for optional hex")
+		require.Empty(t, s)
+	})
+}
+
+// TestReaderHoldErrorReadVarInt32PriorError covers the early-return-on-prior-error
+// branch of ReaderHoldError.ReadVarInt32 (reader.go:308-309).
+func TestReaderHoldErrorReadVarInt32PriorError(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReaderHoldError([]byte{})
+	r.ReadByteValue() // sets r.Err
+	v := r.ReadVarInt32()
+	require.Error(t, r.Err)
+	require.Equal(t, uint32(0), v)
+}
+
+// TestReaderHoldErrorReadTxidSlicePriorError covers the early-return-on-prior-error
+// branch of ReaderHoldError.ReadTxidSlice (reader.go:406-407).
+func TestReaderHoldErrorReadTxidSlicePriorError(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReaderHoldError([]byte{})
+	r.ReadByteValue() // sets r.Err
+	result := r.ReadTxidSlice()
+	require.Error(t, r.Err)
+	require.Nil(t, result)
+}
+
+// TestReaderHoldErrorReadBytesErrorNoMessage covers the getErr branch where an
+// error is returned without a custom message wrapper (reader.go:470-471).
+func TestReaderHoldErrorReadBytesErrorNoMessage(t *testing.T) {
+	t.Parallel()
+
+	// A fresh reader (no prior error) that reads past the end, with no custom
+	// error message, exercises getErr's len(errMsg)==0 return path.
+	r := util.NewReaderHoldError([]byte{0x01})
+	b := r.ReadBytes(5)
+	require.Error(t, r.Err)
+	require.Contains(t, r.Err.Error(), "read past end of data")
+	require.Nil(t, b)
+}

--- a/wallet/cached_key_deriver_extra_test.go
+++ b/wallet/cached_key_deriver_extra_test.go
@@ -1,0 +1,49 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+)
+
+// TestCachedKeyDeriverDeriveErrors verifies that derivation errors from the
+// underlying KeyDeriver are propagated (and wrapped) by CachedKeyDeriver.
+func TestCachedKeyDeriverDeriveErrors(t *testing.T) {
+	t.Parallel()
+
+	rootKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	other, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	cached := NewCachedKeyDeriver(rootKey, 0)
+
+	// A protocol name shorter than 5 characters makes computeInvoiceNumber fail.
+	badProtocol := Protocol{SecurityLevel: SecurityLevelSilent, Protocol: "ab"}
+	self := Counterparty{Type: CounterpartyTypeSelf}
+	otherCP := Counterparty{Type: CounterpartyTypeOther, Counterparty: other.PubKey()}
+
+	t.Run("DerivePublicKey error", func(t *testing.T) {
+		t.Parallel()
+		_, err := cached.DerivePublicKey(badProtocol, "k1", self, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive public key")
+	})
+
+	t.Run("DerivePrivateKey error", func(t *testing.T) {
+		t.Parallel()
+		_, err := cached.DerivePrivateKey(badProtocol, "k1", self)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive private key")
+	})
+
+	t.Run("RevealSpecificSecret error", func(t *testing.T) {
+		t.Parallel()
+		_, err := cached.RevealSpecificSecret(otherCP, badProtocol, "k1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to reveal specific secret")
+	})
+}

--- a/wallet/encoding_extra_test.go
+++ b/wallet/encoding_extra_test.go
@@ -1,0 +1,91 @@
+package wallet_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func TestBytesListUnmarshalJSONError(t *testing.T) {
+	t.Parallel()
+	var bl wallet.BytesList
+	// A JSON string is not a valid []uint8 array.
+	err := json.Unmarshal([]byte(`"not-an-array"`), &bl)
+	assert.Error(t, err)
+}
+
+func TestBytesHexUnmarshalNotAString(t *testing.T) {
+	t.Parallel()
+	var bh wallet.BytesHex
+	err := json.Unmarshal([]byte(`123`), &bh)
+	assert.Error(t, err)
+}
+
+func TestBytes32Base64UnmarshalErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not a string", func(t *testing.T) {
+		t.Parallel()
+		var b wallet.Bytes32Base64
+		err := json.Unmarshal([]byte(`42`), &b)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid base64", func(t *testing.T) {
+		t.Parallel()
+		var b wallet.Bytes32Base64
+		err := json.Unmarshal([]byte(`"!!!!"`), &b)
+		assert.Error(t, err)
+	})
+}
+
+func TestBytes33HexUnmarshalErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not a string", func(t *testing.T) {
+		t.Parallel()
+		var b wallet.Bytes33Hex
+		err := json.Unmarshal([]byte(`42`), &b)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid hex", func(t *testing.T) {
+		t.Parallel()
+		var b wallet.Bytes33Hex
+		err := json.Unmarshal([]byte(`"zz"`), &b)
+		assert.Error(t, err)
+	})
+}
+
+func TestStringBase64ToArrayTooLong(t *testing.T) {
+	t.Parallel()
+	long := base64.StdEncoding.EncodeToString(make([]byte, 40))
+	_, err := wallet.StringBase64(long).ToArray()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "string too long")
+}
+
+func TestSignatureUnmarshalJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not a byte array", func(t *testing.T) {
+		t.Parallel()
+		var s wallet.Signature
+		err := json.Unmarshal([]byte(`"not-an-array"`), &s)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid signature bytes", func(t *testing.T) {
+		t.Parallel()
+		var s wallet.Signature
+		// Valid []uint8 JSON array but not a parseable DER signature.
+		err := json.Unmarshal([]byte(`[1,2,3]`), &s)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not parse signature")
+	})
+}

--- a/wallet/encoding_json_extra_test.go
+++ b/wallet/encoding_json_extra_test.go
@@ -1,0 +1,255 @@
+package wallet_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// TestUnmarshalJSONMalformedInput feeds invalid JSON to every custom
+// json.Unmarshaler in the wallet package, exercising the shared
+// "json.Unmarshal returned an error" branch in each implementation.
+func TestUnmarshalJSONMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	// A bare JSON number is a valid top-level token (so each custom UnmarshalJSON
+	// is actually invoked) but cannot be decoded into the target struct/string/slice,
+	// which exercises the internal json.Unmarshal error branch.
+	const invalid = "123"
+
+	unmarshalers := map[string]func([]byte) error{
+		"Protocol":     func(b []byte) error { var v wallet.Protocol; return json.Unmarshal(b, &v) },
+		"Counterparty": func(b []byte) error { var v wallet.Counterparty; return json.Unmarshal(b, &v) },
+		"CreateSignatureResult": func(b []byte) error {
+			var v wallet.CreateSignatureResult
+			return json.Unmarshal(b, &v)
+		},
+		"VerifySignatureArgs": func(b []byte) error { var v wallet.VerifySignatureArgs; return json.Unmarshal(b, &v) },
+		"Certificate":         func(b []byte) error { var v wallet.Certificate; return json.Unmarshal(b, &v) },
+		"CreateActionInput":   func(b []byte) error { var v wallet.CreateActionInput; return json.Unmarshal(b, &v) },
+		"CreateActionOutput":  func(b []byte) error { var v wallet.CreateActionOutput; return json.Unmarshal(b, &v) },
+		"SignActionSpend":     func(b []byte) error { var v wallet.SignActionSpend; return json.Unmarshal(b, &v) },
+		"ActionInput":         func(b []byte) error { var v wallet.ActionInput; return json.Unmarshal(b, &v) },
+		"ActionOutput":        func(b []byte) error { var v wallet.ActionOutput; return json.Unmarshal(b, &v) },
+		"InternalizeActionArgs": func(b []byte) error {
+			var v wallet.InternalizeActionArgs
+			return json.Unmarshal(b, &v)
+		},
+		"Output":            func(b []byte) error { var v wallet.Output; return json.Unmarshal(b, &v) },
+		"ListOutputsResult": func(b []byte) error { var v wallet.ListOutputsResult; return json.Unmarshal(b, &v) },
+		"CertificateResult": func(b []byte) error { var v wallet.CertificateResult; return json.Unmarshal(b, &v) },
+		"RevealCounterpartyKeyLinkageResult": func(b []byte) error {
+			var v wallet.RevealCounterpartyKeyLinkageResult
+			return json.Unmarshal(b, &v)
+		},
+		"RevealSpecificKeyLinkageResult": func(b []byte) error {
+			var v wallet.RevealSpecificKeyLinkageResult
+			return json.Unmarshal(b, &v)
+		},
+		"IdentityCertificate": func(b []byte) error { var v wallet.IdentityCertificate; return json.Unmarshal(b, &v) },
+		"KeyringRevealer":     func(b []byte) error { var v wallet.KeyringRevealer; return json.Unmarshal(b, &v) },
+		"AcquireCertificateArgs": func(b []byte) error {
+			var v wallet.AcquireCertificateArgs
+			return json.Unmarshal(b, &v)
+		},
+		"GetHeaderResult": func(b []byte) error { var v wallet.GetHeaderResult; return json.Unmarshal(b, &v) },
+		"VerifyHMACArgs":  func(b []byte) error { var v wallet.VerifyHMACArgs; return json.Unmarshal(b, &v) },
+		"CreateHMACResult": func(b []byte) error {
+			var v wallet.CreateHMACResult
+			return json.Unmarshal(b, &v)
+		},
+	}
+
+	for name, fn := range unmarshalers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Error(t, fn([]byte(invalid)))
+		})
+	}
+}
+
+// ---- Protocol edge cases ----
+
+func TestProtocolUnmarshalProtocolNotString(t *testing.T) {
+	t.Parallel()
+	var p wallet.Protocol
+	err := json.Unmarshal([]byte(`[2, 123]`), &p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Protocol to be a string")
+}
+
+// ---- Counterparty MarshalJSON edge cases ----
+
+func TestCounterpartyMarshalOtherNil(t *testing.T) {
+	t.Parallel()
+	c := wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: nil}
+	data, err := json.Marshal(&c)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+func TestCounterpartyMarshalUninitialized(t *testing.T) {
+	t.Parallel()
+	c := wallet.Counterparty{Type: wallet.CounterpartyUninitialized}
+	data, err := json.Marshal(&c)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+func TestCounterpartyMarshalUnknownType(t *testing.T) {
+	t.Parallel()
+	c := wallet.Counterparty{Type: wallet.CounterpartyType(99)}
+	data, err := json.Marshal(&c)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+// ---- VerifySignatureArgs JSON round trip (custom marshaler + unmarshaler) ----
+
+func TestVerifySignatureArgsMarshalUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	privKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	sig, err := privKey.Sign(make([]byte, 32))
+	require.NoError(t, err)
+
+	args := wallet.VerifySignatureArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Data:      []byte{1, 2, 3},
+		Signature: sig,
+	}
+
+	data, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	var decoded wallet.VerifySignatureArgs
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, args.Data, decoded.Data)
+	require.NotNil(t, decoded.Signature)
+}
+
+func TestVerifySignatureArgsUnmarshalInvalidSignature(t *testing.T) {
+	t.Parallel()
+	// Valid JSON structure, but the signature byte array cannot be parsed.
+	data := []byte(`{"data":[1,2,3],"signature":[1,2,3],"protocolID":[0,"test"],"keyID":"k"}`)
+	var decoded wallet.VerifySignatureArgs
+	err := json.Unmarshal(data, &decoded)
+	assert.Error(t, err)
+}
+
+// ---- Certificate signature branches ----
+
+func TestCertificateMarshalWithSignature(t *testing.T) {
+	t.Parallel()
+	privKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	sig, err := privKey.Sign(make([]byte, 32))
+	require.NoError(t, err)
+
+	ct, err := wallet.CertificateTypeFromString("testcert")
+	require.NoError(t, err)
+	cert := wallet.Certificate{
+		Type:      ct,
+		Subject:   privKey.PubKey(),
+		Signature: sig,
+	}
+	data, err := json.Marshal(cert)
+	require.NoError(t, err)
+
+	var decoded wallet.Certificate
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Signature)
+}
+
+func TestCertificateUnmarshalInvalidSignature(t *testing.T) {
+	t.Parallel()
+	// "01" is valid hex but not a parseable signature.
+	data := []byte(`{"signature":"01"}`)
+	var cert wallet.Certificate
+	err := json.Unmarshal(data, &cert)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing signature")
+}
+
+// ---- KeyringRevealer invalid public key ----
+
+func TestKeyringRevealerUnmarshalInvalidPubKey(t *testing.T) {
+	t.Parallel()
+	var r wallet.KeyringRevealer
+	err := json.Unmarshal([]byte(`"not-a-valid-pubkey"`), &r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing revealer public key")
+}
+
+// ---- AcquireCertificateArgs invalid signature ----
+
+func TestAcquireCertificateArgsUnmarshalInvalidSignature(t *testing.T) {
+	t.Parallel()
+	// signature is valid hex but not a parseable signature.
+	data := []byte(`{"signature":"01"}`)
+	var args wallet.AcquireCertificateArgs
+	err := json.Unmarshal(data, &args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing signature")
+}
+
+// ---- CertificateResult keyring/verifier error branches ----
+
+func TestCertificateResultUnmarshalFieldErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid keyring", func(t *testing.T) {
+		t.Parallel()
+		// Base certificate decodes fine; keyring is the wrong JSON type.
+		var cr wallet.CertificateResult
+		err := json.Unmarshal([]byte(`{"keyring":123}`), &cr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "keyring")
+	})
+
+	t.Run("invalid verifier", func(t *testing.T) {
+		t.Parallel()
+		var cr wallet.CertificateResult
+		err := json.Unmarshal([]byte(`{"verifier":123}`), &cr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "verifier")
+	})
+}
+
+// ---- IdentityCertificate field error branches ----
+
+func TestIdentityCertificateUnmarshalFieldErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid certifierInfo", func(t *testing.T) {
+		t.Parallel()
+		var ic wallet.IdentityCertificate
+		err := json.Unmarshal([]byte(`{"certifierInfo":123}`), &ic)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "certifierInfo")
+	})
+
+	t.Run("invalid publiclyRevealedKeyring", func(t *testing.T) {
+		t.Parallel()
+		var ic wallet.IdentityCertificate
+		err := json.Unmarshal([]byte(`{"publiclyRevealedKeyring":123}`), &ic)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "publiclyRevealedKeyring")
+	})
+
+	t.Run("invalid decryptedFields", func(t *testing.T) {
+		t.Parallel()
+		var ic wallet.IdentityCertificate
+		err := json.Unmarshal([]byte(`{"decryptedFields":123}`), &ic)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decryptedFields")
+	})
+}

--- a/wallet/key_deriver_extra_test.go
+++ b/wallet/key_deriver_extra_test.go
@@ -1,0 +1,168 @@
+package wallet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func kdProtocol() wallet.Protocol {
+	return wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "testprotocol"}
+}
+
+func kdBadProtocol() wallet.Protocol {
+	return wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "ab"}
+}
+
+func TestKeyDeriverDerivePublicKeyBranches(t *testing.T) {
+	t.Parallel()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	kd := wallet.NewKeyDeriver(pk)
+
+	t.Run("forSelf true", func(t *testing.T) {
+		t.Parallel()
+		pub, err := kd.DerivePublicKey(kdProtocol(), "k1", wallet.Counterparty{Type: wallet.CounterpartyTypeSelf}, true)
+		require.NoError(t, err)
+		require.NotNil(t, pub)
+	})
+
+	t.Run("counterparty other with nil key", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.DerivePublicKey(kdProtocol(), "k1", wallet.Counterparty{Type: wallet.CounterpartyTypeOther}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty public key required for other")
+	})
+
+	t.Run("uninitialized counterparty", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.DerivePublicKey(kdProtocol(), "k1", wallet.Counterparty{Type: wallet.CounterpartyUninitialized}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid counterparty")
+	})
+
+	t.Run("compute invoice number failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.DerivePublicKey(kdBadProtocol(), "k1", wallet.Counterparty{Type: wallet.CounterpartyTypeSelf}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invoice number")
+	})
+}
+
+func TestKeyDeriverDerivePrivateKeyBranches(t *testing.T) {
+	t.Parallel()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	kd := wallet.NewKeyDeriver(pk)
+
+	t.Run("counterparty other with nil key", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.DerivePrivateKey(kdProtocol(), "k1", wallet.Counterparty{Type: wallet.CounterpartyTypeOther})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty public key required for other")
+	})
+
+	t.Run("compute invoice number failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.DerivePrivateKey(kdBadProtocol(), "k1", wallet.Counterparty{Type: wallet.CounterpartyTypeSelf})
+		require.Error(t, err)
+	})
+}
+
+func TestKeyDeriverDeriveSymmetricKeyError(t *testing.T) {
+	t.Parallel()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	other, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	kd := wallet.NewKeyDeriver(pk)
+
+	_, err = kd.DeriveSymmetricKey(kdBadProtocol(), "k1", wallet.Counterparty{
+		Type:         wallet.CounterpartyTypeOther,
+		Counterparty: other.PubKey(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to derive public key")
+}
+
+func TestKeyDeriverRevealSpecificSecretErrors(t *testing.T) {
+	t.Parallel()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	other, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	kd := wallet.NewKeyDeriver(pk)
+
+	t.Run("normalize counterparty failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.RevealSpecificSecret(wallet.Counterparty{Type: wallet.CounterpartyTypeOther}, kdProtocol(), "k1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to normalize counterparty")
+	})
+
+	t.Run("compute invoice number failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := kd.RevealSpecificSecret(
+			wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: other.PubKey()},
+			kdBadProtocol(), "k1",
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invoice number")
+	})
+}
+
+func TestKeyDeriverRevealCounterpartySecretNormalizeError(t *testing.T) {
+	t.Parallel()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	kd := wallet.NewKeyDeriver(pk)
+
+	_, err = kd.RevealCounterpartySecret(wallet.Counterparty{Type: wallet.CounterpartyUninitialized})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to normalize counterparty")
+}
+
+// TestRevealSpecificKeyLinkageCounterpartyBranches covers getCounterpartyPublicKey's
+// "other with nil key" and "uninitialized" branches via RevealSpecificKeyLinkage.
+func TestRevealSpecificKeyLinkageCounterpartyBranches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifier, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	w, err := wallet.NewProtoWallet(wallet.ProtoWalletArgs{
+		Type:       wallet.ProtoWalletArgsTypePrivateKey,
+		PrivateKey: pk,
+	})
+	require.NoError(t, err)
+
+	t.Run("other with nil key", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.RevealSpecificKeyLinkage(ctx, wallet.RevealSpecificKeyLinkageArgs{
+			Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeOther},
+			Verifier:     verifier.PubKey(),
+			ProtocolID:   kdProtocol(),
+			KeyID:        "k1",
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty public key is required")
+	})
+
+	t.Run("uninitialized", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.RevealSpecificKeyLinkage(ctx, wallet.RevealSpecificKeyLinkageArgs{
+			Counterparty: wallet.Counterparty{Type: wallet.CounterpartyUninitialized},
+			Verifier:     verifier.PubKey(),
+			ProtocolID:   kdProtocol(),
+			KeyID:        "k1",
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid counterparty type")
+	})
+}

--- a/wallet/proto_wallet_extra_test.go
+++ b/wallet/proto_wallet_extra_test.go
@@ -1,0 +1,273 @@
+package wallet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func newRealProto(t *testing.T) *wallet.ProtoWallet {
+	t.Helper()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	w, err := wallet.NewProtoWallet(wallet.ProtoWalletArgs{
+		Type:       wallet.ProtoWalletArgsTypePrivateKey,
+		PrivateKey: pk,
+	})
+	require.NoError(t, err)
+	return w
+}
+
+// newNilKeyDeriverProto returns a ProtoWallet whose keyDeriver is nil, so every
+// crypto method returns "keyDeriver is undefined".
+func newNilKeyDeriverProto(t *testing.T) *wallet.ProtoWallet {
+	t.Helper()
+	w, err := wallet.NewProtoWallet(wallet.ProtoWalletArgs{
+		Type:       wallet.ProtoWalletArgsTypeKeyDeriver,
+		KeyDeriver: nil,
+	})
+	require.NoError(t, err)
+	return w
+}
+
+func validProtocol() wallet.Protocol {
+	return wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "testprotocol"}
+}
+
+// badProtocol has a protocol name that is too short, so computeInvoiceNumber fails.
+func badProtocol() wallet.Protocol {
+	return wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "ab"}
+}
+
+func TestNewProtoWalletVariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("anyone", func(t *testing.T) {
+		t.Parallel()
+		w, err := wallet.NewProtoWallet(wallet.ProtoWalletArgs{Type: wallet.ProtoWalletArgsTypeAnyone})
+		require.NoError(t, err)
+		require.NotNil(t, w)
+	})
+
+	t.Run("keyDeriver", func(t *testing.T) {
+		t.Parallel()
+		pk, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+		w, err := wallet.NewProtoWallet(wallet.ProtoWalletArgs{
+			Type:       wallet.ProtoWalletArgsTypeKeyDeriver,
+			KeyDeriver: wallet.NewKeyDeriver(pk),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, w)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		t.Parallel()
+		_, err := wallet.NewProtoWallet(wallet.ProtoWalletArgs{Type: wallet.ProtoWalletArgsType("bogus")})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid rootKeyOrKeyDeriver")
+	})
+}
+
+func TestProtoWalletNilKeyDeriver(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	w := newNilKeyDeriverProto(t)
+
+	const wantErr = "keyDeriver is undefined"
+
+	t.Run("GetPublicKey identity", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.GetPublicKey(ctx, wallet.GetPublicKeyArgs{IdentityKey: true}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("GetPublicKey derived", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.GetPublicKey(ctx, wallet.GetPublicKeyArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("Encrypt", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.Encrypt(ctx, wallet.EncryptArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Plaintext:      []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("Decrypt", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.Decrypt(ctx, wallet.DecryptArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Ciphertext:     []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("CreateSignature", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.CreateSignature(ctx, wallet.CreateSignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("VerifySignature", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.VerifySignature(ctx, wallet.VerifySignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("CreateHMAC", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.CreateHMAC(ctx, wallet.CreateHMACArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+
+	t.Run("VerifyHMAC", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.VerifyHMAC(ctx, wallet.VerifyHMACArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), wantErr)
+	})
+}
+
+func TestProtoWalletGetPublicKeyValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	w := newRealProto(t)
+
+	t.Run("missing protocolID and keyID", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.GetPublicKey(ctx, wallet.GetPublicKeyArgs{}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "protocolID and keyID are required")
+	})
+
+	t.Run("derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.GetPublicKey(ctx, wallet.GetPublicKeyArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive public key")
+	})
+}
+
+func TestProtoWalletDeriveErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	w := newRealProto(t)
+
+	t.Run("Encrypt derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.Encrypt(ctx, wallet.EncryptArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+			Plaintext:      []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive symmetric key")
+	})
+
+	t.Run("Decrypt derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.Decrypt(ctx, wallet.DecryptArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+			Ciphertext:     []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive symmetric key")
+	})
+
+	t.Run("CreateSignature derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.CreateSignature(ctx, wallet.CreateSignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive private key")
+	})
+
+	t.Run("CreateHMAC derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.CreateHMAC(ctx, wallet.CreateHMACArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive symmetric key")
+	})
+
+	t.Run("VerifyHMAC derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.VerifyHMAC(ctx, wallet.VerifyHMACArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive symmetric key")
+	})
+}
+
+func TestProtoWalletVerifySignatureBranches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	w := newRealProto(t)
+
+	t.Run("no data and no hash", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.VerifySignature(ctx, wallet.VerifySignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be valid")
+	})
+
+	t.Run("derive failure", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.VerifySignature(ctx, wallet.VerifySignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: badProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to derive public key")
+	})
+
+	t.Run("nil signature", func(t *testing.T) {
+		t.Parallel()
+		_, err := w.VerifySignature(ctx, wallet.VerifySignatureArgs{
+			EncryptionArgs: wallet.EncryptionArgs{ProtocolID: validProtocol(), KeyID: "k1"},
+			Data:           []byte("x"),
+			Signature:      nil,
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signature is nil")
+	})
+}

--- a/wallet/serializer/certificate_extra_test.go
+++ b/wallet/serializer/certificate_extra_test.go
@@ -1,0 +1,52 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+)
+
+func TestSerializeCertificateNoSignature(t *testing.T) {
+	t.Parallel()
+
+	cert := xtValidCertificate(t)
+
+	data, err := SerializeCertificateNoSignature(&cert)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	// The no-signature form omits the trailing signature, so a round-trip
+	// decode yields a certificate with a nil signature.
+	got, err := DeserializeCertificate(data)
+	require.NoError(t, err)
+	assert.Nil(t, got.Signature)
+}
+
+func TestSerializeCertificateNoSignatureEmptyType(t *testing.T) {
+	t.Parallel()
+
+	cert := xtValidCertificate(t)
+	cert.Type = [32]byte{}
+
+	_, err := SerializeCertificateNoSignature(&cert)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cert type is empty")
+}
+
+func TestDeserializeCertificateInvalidCertifier(t *testing.T) {
+	t.Parallel()
+
+	w := util.NewWriter()
+	w.WriteBytes(make([]byte, sizeType))     // type
+	w.WriteBytes(make([]byte, sizeSerial))   // serial number
+	w.WriteBytes(xtPub(t).Compressed())      // valid subject public key
+	w.WriteByteValue(0x01)                   // invalid magic for certifier public key
+	w.WriteBytes(make([]byte, sizePubKey-1)) // remaining certifier bytes
+
+	_, err := DeserializeCertificate(w.Buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing certifier key")
+}

--- a/wallet/serializer/deserialize_errors_extra_test.go
+++ b/wallet/serializer/deserialize_errors_extra_test.go
@@ -1,0 +1,146 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// xtValidKeyParams returns encoded key-related params for a self counterparty.
+func xtValidKeyParams(t *testing.T) []byte {
+	t.Helper()
+	kp, err := encodeKeyRelatedParams(KeyRelatedParams{
+		ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "p"},
+		Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+	})
+	require.NoError(t, err)
+	return kp
+}
+
+func TestDeserializeListActionsArgsInvalidQueryMode(t *testing.T) {
+	t.Parallel()
+
+	w := util.NewWriter()
+	w.WriteStringSlice([]string{}) // labels
+	w.WriteByteValue(0x05)         // invalid label query mode byte
+	_, err := DeserializeListActionsArgs(w.Buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid label query mode byte")
+}
+
+func TestDeserializeListActionsResultInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	w := util.NewWriter()
+	w.WriteVarInt(1)                      // TotalActions
+	w.WriteBytesReverse(make([]byte, 32)) // txid
+	w.WriteVarInt(1000)                   // satoshis
+	w.WriteByteValue(0x09)                // invalid status byte
+	_, err := DeserializeListActionsResult(w.Buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid status byte")
+}
+
+func TestDeserializeInternalizeActionArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid protocol byte", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(0)       // tx length
+		w.WriteVarInt(1)       // output count
+		w.WriteVarInt(0)       // output index
+		w.WriteByteValue(0x09) // invalid protocol
+		_, err := DeserializeInternalizeActionArgs(w.Buf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid internalize action protocol")
+	})
+
+	t.Run("bad sender identity key", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(0)               // tx length
+		w.WriteVarInt(1)               // output count
+		w.WriteVarInt(0)               // output index
+		w.WriteByteValue(1)            // wallet payment protocol
+		w.WriteByteValue(0x01)         // invalid pubkey magic
+		w.WriteBytes(make([]byte, 32)) // rest of the (invalid) 33-byte key
+		_, err := DeserializeInternalizeActionArgs(w.Buf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing sender identity key")
+	})
+}
+
+func TestDeserializeCreateSignatureArgsInvalidDataFlag(t *testing.T) {
+	t.Parallel()
+
+	w := util.NewWriter()
+	w.WriteBytes(xtValidKeyParams(t))
+	w.WriteByteValue(0x09) // invalid data type flag
+	_, err := DeserializeCreateSignatureArgs(w.Buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid data type flag")
+}
+
+func TestDeserializeVerifySignatureArgsInvalidDataFlag(t *testing.T) {
+	t.Parallel()
+
+	sig := newTestSignature(t)
+	w := util.NewWriter()
+	w.WriteBytes(xtValidKeyParams(t))
+	w.WriteOptionalBool(nil)         // forSelf
+	w.WriteIntBytes(sig.Serialize()) // valid signature
+	w.WriteByteValue(0x09)           // invalid data type flag
+	_, err := DeserializeVerifySignatureArgs(w.Buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid data type flag")
+}
+
+func TestDeserializeAcquireCertificateArgsInvalidProtocolFlag(t *testing.T) {
+	t.Parallel()
+
+	pub := xtPub(t)
+	w := util.NewWriter()
+	w.WriteBytes(make([]byte, 32))                // type
+	w.WriteBytes(pub.Compressed())                // valid certifier
+	w.WriteVarInt(0)                              // fields length
+	w.WriteBytes(encodePrivilegedParams(nil, "")) // privileged params
+	w.WriteByteValue(0x09)                        // invalid acquisition protocol flag
+	_, err := DeserializeAcquireCertificateArgs(w.Buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid acquisition protocol flag")
+}
+
+func TestDeserializeCreateHMACResultTooShort(t *testing.T) {
+	t.Parallel()
+
+	_, err := DeserializeCreateHMACResult(make([]byte, 31))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "data too short")
+}
+
+func TestDeserializeRelinquishOutputResultNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, err := DeserializeRelinquishOutputResult([]byte{0x01})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid result data length")
+}
+
+func TestDeserializeGetPublicKeyResultInvalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := DeserializeGetPublicKeyResult([]byte{0x01})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing result public key")
+}
+
+func TestDeserializeCreateSignatureResultInvalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := DeserializeCreateSignatureResult([]byte{0x01, 0x02})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error parsing signature")
+}

--- a/wallet/serializer/deserialize_sweep_extra_test.go
+++ b/wallet/serializer/deserialize_sweep_extra_test.go
@@ -1,0 +1,609 @@
+package serializer
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/util"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// runDeserializeSweep verifies a full round-trip decode succeeds, an empty input
+// errors, and then feeds every truncated prefix to the deserializer to exercise
+// the short-buffer error branches. Truncated calls must never panic.
+func runDeserializeSweep(t *testing.T, good []byte, deser func([]byte) error) {
+	t.Helper()
+	require.NoError(t, deser(good), "full buffer should deserialize without error")
+	require.Error(t, deser(nil), "empty buffer should error")
+	for n := 1; n < len(good); n++ {
+		_ = deser(good[:n]) // exercise truncation error paths
+	}
+}
+
+func TestDeserializeTruncationSweep(t *testing.T) {
+	t.Parallel()
+
+	pub := xtPub(t)
+	sig := newTestSignature(t)
+	op := tu.OutpointFromString(t, "a755810c21e17183ff6db6685f0de239fd3a0a3c0d4ba7773b0b0d1748541e2b.0")
+	hash := tu.HashFromString(t, "b1f4d452814bba0ac422318083850b706d5f23ce232c789eefe5cbdcf2cc47de")
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	serOK := func(data []byte, err error) []byte {
+		t.Helper()
+		require.NoError(t, err, "serializing the valid fixture should not error")
+		require.NotEmpty(t, data, "serialized fixture should not be empty")
+		return data
+	}
+
+	encArgs := wallet.EncryptionArgs{
+		ProtocolID:       wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "p"},
+		KeyID:            "k",
+		Counterparty:     wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: pub},
+		Privileged:       true,
+		PrivilegedReason: "r",
+		SeekPermission:   true,
+	}
+
+	t.Run("AcquireCertificateArgs", func(t *testing.T) {
+		args := &wallet.AcquireCertificateArgs{
+			Type:                tu.GetByte32FromString("test-type"),
+			Certifier:           pub,
+			AcquisitionProtocol: wallet.AcquisitionProtocolDirect,
+			Fields:              map[string]string{"f1": "v1"},
+			SerialNumber:        &wallet.SerialNumber{1},
+			RevocationOutpoint:  op,
+			Signature:           sig,
+			KeyringRevealer:     &wallet.KeyringRevealer{PubKey: pub},
+			KeyringForSubject:   map[string]string{"f1": b64("k1")},
+			Privileged:          util.BoolPtr(true),
+			PrivilegedReason:    "reason",
+		}
+		good := serOK(SerializeAcquireCertificateArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeAcquireCertificateArgs(d)
+			return err
+		})
+	})
+
+	t.Run("Certificate", func(t *testing.T) {
+		cert := xtValidCertificate(t)
+		good := serOK(SerializeCertificate(&cert))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCertificate(d)
+			return err
+		})
+	})
+
+	t.Run("IdentityCertificate", func(t *testing.T) {
+		idcert := xtValidIdentityCertificate(t)
+		good := serOK(SerializeIdentityCertificate(&idcert))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeIdentityCertificate(util.NewReaderHoldError(d))
+			return err
+		})
+	})
+
+	t.Run("CreateActionArgs", func(t *testing.T) {
+		args := &wallet.CreateActionArgs{
+			Description: "desc",
+			InputBEEF:   []byte{1, 2, 3},
+			Inputs: []wallet.CreateActionInput{{
+				Outpoint:              *op,
+				InputDescription:      "in1",
+				UnlockingScript:       []byte{0xab, 0xcd},
+				UnlockingScriptLength: 2,
+				SequenceNumber:        util.Uint32Ptr(1),
+			}},
+			Outputs: []wallet.CreateActionOutput{{
+				LockingScript:      []byte{0x76, 0xa9},
+				Satoshis:           1000,
+				OutputDescription:  "out1",
+				Basket:             "b1",
+				CustomInstructions: "ci",
+				Tags:               []string{"t1"},
+			}},
+			LockTime: util.Uint32Ptr(100),
+			Version:  util.Uint32Ptr(1),
+			Labels:   []string{"l1"},
+			Options: &wallet.CreateActionOptions{
+				SignAndProcess:         util.BoolPtr(true),
+				AcceptDelayedBroadcast: util.BoolPtr(false),
+				TrustSelf:              wallet.TrustSelfKnown,
+				KnownTxids:             []chainhash.Hash{hash},
+				ReturnTXIDOnly:         util.BoolPtr(true),
+				NoSend:                 util.BoolPtr(false),
+				NoSendChange:           []transaction.Outpoint{*op},
+				SendWith:               []chainhash.Hash{hash},
+				RandomizeOutputs:       util.BoolPtr(true),
+			},
+		}
+		good := serOK(SerializeCreateActionArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCreateActionArgs(d)
+			return err
+		})
+	})
+
+	t.Run("CreateActionResult", func(t *testing.T) {
+		result := &wallet.CreateActionResult{
+			Txid:         tu.GetByte32FromHexString(t, "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
+			Tx:           []byte{1, 2, 3},
+			NoSendChange: []transaction.Outpoint{*op},
+			SendWithResults: []wallet.SendWithResult{
+				{Txid: tu.GetByte32FromHexString(t, "8a552c995db3602e85bb9df911803897d1ea17ba5cdd198605d014be49db9f72"), Status: wallet.ActionResultStatusUnproven},
+			},
+			SignableTransaction: &wallet.SignableTransaction{Tx: []byte{4, 5, 6}, Reference: []byte("ref")},
+		}
+		good := serOK(SerializeCreateActionResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCreateActionResult(d)
+			return err
+		})
+	})
+
+	t.Run("CreateHMACArgs", func(t *testing.T) {
+		args := &wallet.CreateHMACArgs{EncryptionArgs: encArgs, Data: []byte{1, 2, 3}}
+		good := serOK(SerializeCreateHMACArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCreateHMACArgs(d)
+			return err
+		})
+	})
+
+	t.Run("CreateHMACResult", func(t *testing.T) {
+		good := serOK(SerializeCreateHMACResult(&wallet.CreateHMACResult{HMAC: [32]byte{1, 2, 3, 4}}))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCreateHMACResult(d)
+			return err
+		})
+	})
+
+	t.Run("CreateSignatureArgs", func(t *testing.T) {
+		args := &wallet.CreateSignatureArgs{EncryptionArgs: encArgs, Data: []byte{5, 6, 7, 8}}
+		good := serOK(SerializeCreateSignatureArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCreateSignatureArgs(d)
+			return err
+		})
+	})
+
+	t.Run("CreateSignatureResult", func(t *testing.T) {
+		good := serOK(SerializeCreateSignatureResult(&wallet.CreateSignatureResult{Signature: sig}))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeCreateSignatureResult(d)
+			return err
+		})
+	})
+
+	t.Run("DecryptArgs", func(t *testing.T) {
+		args := &wallet.DecryptArgs{EncryptionArgs: encArgs, Ciphertext: []byte{9, 9, 9}}
+		good := serOK(SerializeDecryptArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeDecryptArgs(d)
+			return err
+		})
+	})
+
+	t.Run("EncryptArgs", func(t *testing.T) {
+		args := &wallet.EncryptArgs{EncryptionArgs: encArgs, Plaintext: []byte{7, 7, 7}}
+		good := serOK(SerializeEncryptArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeEncryptArgs(d)
+			return err
+		})
+	})
+
+	t.Run("DiscoverByAttributesArgs", func(t *testing.T) {
+		args := &wallet.DiscoverByAttributesArgs{
+			Attributes:     map[string]string{"a": "b"},
+			Limit:          util.Uint32Ptr(10),
+			Offset:         util.Uint32Ptr(5),
+			SeekPermission: util.BoolPtr(true),
+		}
+		good := serOK(SerializeDiscoverByAttributesArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeDiscoverByAttributesArgs(d)
+			return err
+		})
+	})
+
+	t.Run("DiscoverByIdentityKeyArgs", func(t *testing.T) {
+		args := &wallet.DiscoverByIdentityKeyArgs{
+			IdentityKey:    pub,
+			Limit:          util.Uint32Ptr(10),
+			Offset:         util.Uint32Ptr(5),
+			SeekPermission: util.BoolPtr(true),
+		}
+		good := serOK(SerializeDiscoverByIdentityKeyArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeDiscoverByIdentityKeyArgs(d)
+			return err
+		})
+	})
+
+	t.Run("DiscoverCertificatesResult", func(t *testing.T) {
+		idcert := xtValidIdentityCertificate(t)
+		result := &wallet.DiscoverCertificatesResult{
+			TotalCertificates: 1,
+			Certificates:      []wallet.IdentityCertificate{idcert},
+		}
+		good := serOK(SerializeDiscoverCertificatesResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeDiscoverCertificatesResult(d)
+			return err
+		})
+	})
+
+	t.Run("GetHeaderArgs", func(t *testing.T) {
+		good := serOK(SerializeGetHeaderArgs(&wallet.GetHeaderArgs{Height: 123456}))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeGetHeaderArgs(d)
+			return err
+		})
+	})
+
+	t.Run("GetNetworkResult", func(t *testing.T) {
+		good := serOK(SerializeGetNetworkResult(&wallet.GetNetworkResult{Network: wallet.NetworkTestnet}))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeGetNetworkResult(d)
+			return err
+		})
+	})
+
+	t.Run("GetPublicKeyArgs", func(t *testing.T) {
+		args := &wallet.GetPublicKeyArgs{
+			ForSelf:        util.BoolPtr(true),
+			EncryptionArgs: encArgs,
+		}
+		good := serOK(SerializeGetPublicKeyArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeGetPublicKeyArgs(d)
+			return err
+		})
+	})
+
+	t.Run("GetPublicKeyResult", func(t *testing.T) {
+		good := serOK(SerializeGetPublicKeyResult(&wallet.GetPublicKeyResult{PublicKey: pub}))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeGetPublicKeyResult(d)
+			return err
+		})
+	})
+
+	t.Run("InternalizeActionArgs", func(t *testing.T) {
+		args := &wallet.InternalizeActionArgs{
+			Tx: []byte{1, 2, 3, 4},
+			Outputs: []wallet.InternalizeOutput{
+				{
+					OutputIndex: 0,
+					Protocol:    wallet.InternalizeProtocolWalletPayment,
+					PaymentRemittance: &wallet.Payment{
+						DerivationPrefix:  []byte("prefix"),
+						DerivationSuffix:  []byte("suffix"),
+						SenderIdentityKey: pub,
+					},
+				},
+				{
+					OutputIndex: 1,
+					Protocol:    wallet.InternalizeProtocolBasketInsertion,
+					InsertionRemittance: &wallet.BasketInsertion{
+						Basket:             "b",
+						CustomInstructions: "ci",
+						Tags:               []string{"t1"},
+					},
+				},
+			},
+			Description:    "desc",
+			Labels:         []string{"l1"},
+			SeekPermission: util.BoolPtr(true),
+		}
+		good := serOK(SerializeInternalizeActionArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeInternalizeActionArgs(d)
+			return err
+		})
+	})
+
+	t.Run("ListActionsArgs", func(t *testing.T) {
+		args := &wallet.ListActionsArgs{
+			Labels:         []string{"l1", "l2"},
+			LabelQueryMode: wallet.QueryModeAll,
+			IncludeLabels:  util.BoolPtr(true),
+			Limit:          util.Uint32Ptr(100),
+			Offset:         util.Uint32Ptr(10),
+			SeekPermission: util.BoolPtr(false),
+		}
+		good := serOK(SerializeListActionsArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeListActionsArgs(d)
+			return err
+		})
+	})
+
+	t.Run("ListActionsResult", func(t *testing.T) {
+		result := &wallet.ListActionsResult{
+			TotalActions: 1,
+			Actions: []wallet.Action{{
+				Txid:        hash,
+				Satoshis:    1000,
+				Status:      wallet.ActionStatusCompleted,
+				IsOutgoing:  true,
+				Description: "a1",
+				Labels:      []string{"l1"},
+				Version:     1,
+				Inputs: []wallet.ActionInput{{
+					SourceOutpoint:      transaction.Outpoint{Txid: hash},
+					SourceSatoshis:      500,
+					SourceLockingScript: []byte{0x76, 0xa9},
+					UnlockingScript:     []byte{0x48, 0x30},
+					InputDescription:    "in1",
+					SequenceNumber:      0xffffffff,
+				}},
+				Outputs: []wallet.ActionOutput{{
+					OutputIndex:        0,
+					Satoshis:           1000,
+					LockingScript:      []byte{0x76, 0xa9},
+					Spendable:          true,
+					OutputDescription:  "out1",
+					Basket:             "b1",
+					Tags:               []string{"t1"},
+					CustomInstructions: "ci",
+				}},
+			}},
+		}
+		good := serOK(SerializeListActionsResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeListActionsResult(d)
+			return err
+		})
+	})
+
+	t.Run("ListCertificatesArgs", func(t *testing.T) {
+		args := &wallet.ListCertificatesArgs{
+			Certifiers:       []*ec.PublicKey{pub},
+			Types:            []wallet.CertificateType{tu.GetByte32FromString("type1")},
+			Limit:            util.Uint32Ptr(10),
+			Offset:           util.Uint32Ptr(5),
+			Privileged:       util.BoolPtr(true),
+			PrivilegedReason: "r",
+		}
+		good := serOK(SerializeListCertificatesArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeListCertificatesArgs(d)
+			return err
+		})
+	})
+
+	t.Run("ListCertificatesResult", func(t *testing.T) {
+		result := &wallet.ListCertificatesResult{
+			TotalCertificates: 1,
+			Certificates: []wallet.CertificateResult{{
+				Certificate: xtValidCertificate(t),
+				Keyring:     map[string]string{"key1": b64("value1")},
+				Verifier:    []byte("verifier1"),
+			}},
+		}
+		good := serOK(SerializeListCertificatesResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeListCertificatesResult(d)
+			return err
+		})
+	})
+
+	t.Run("ListOutputsArgs", func(t *testing.T) {
+		args := &wallet.ListOutputsArgs{
+			Basket:                    "b1",
+			Tags:                      []string{"t1"},
+			TagQueryMode:              wallet.QueryModeAll,
+			Include:                   wallet.OutputIncludeLockingScripts,
+			IncludeCustomInstructions: util.BoolPtr(true),
+			IncludeTags:               util.BoolPtr(true),
+			IncludeLabels:             util.BoolPtr(true),
+			Limit:                     util.Uint32Ptr(10),
+			Offset:                    util.Uint32Ptr(5),
+			SeekPermission:            util.BoolPtr(true),
+		}
+		good := serOK(SerializeListOutputsArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeListOutputsArgs(d)
+			return err
+		})
+	})
+
+	t.Run("ListOutputsResult", func(t *testing.T) {
+		result := &wallet.ListOutputsResult{
+			TotalOutputs: 1,
+			BEEF:         []byte{1, 2, 3},
+			Outputs: []wallet.Output{{
+				Outpoint:           *op,
+				Satoshis:           1000,
+				LockingScript:      []byte{0x76, 0xa9},
+				Spendable:          true,
+				CustomInstructions: "ci",
+				Tags:               []string{"t1"},
+				Labels:             []string{"l1"},
+			}},
+		}
+		good := serOK(SerializeListOutputsResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeListOutputsResult(d)
+			return err
+		})
+	})
+
+	t.Run("ProveCertificateArgs", func(t *testing.T) {
+		args := &wallet.ProveCertificateArgs{
+			Certificate:      xtValidCertificate(t),
+			FieldsToReveal:   []string{"field1"},
+			Verifier:         pub,
+			Privileged:       util.BoolPtr(true),
+			PrivilegedReason: "r",
+		}
+		good := serOK(SerializeProveCertificateArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeProveCertificateArgs(d)
+			return err
+		})
+	})
+
+	t.Run("ProveCertificateResult", func(t *testing.T) {
+		result := &wallet.ProveCertificateResult{
+			KeyringForVerifier: map[string]string{"field1": b64("value1")},
+		}
+		good := serOK(SerializeProveCertificateResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeProveCertificateResult(d)
+			return err
+		})
+	})
+
+	t.Run("RelinquishCertificateArgs", func(t *testing.T) {
+		args := &wallet.RelinquishCertificateArgs{
+			Type:         tu.GetByte32FromString("type1"),
+			SerialNumber: tu.GetByte32FromString("serial1"),
+			Certifier:    pub,
+		}
+		good := serOK(SerializeRelinquishCertificateArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeRelinquishCertificateArgs(d)
+			return err
+		})
+	})
+
+	t.Run("RelinquishOutputArgs", func(t *testing.T) {
+		args := &wallet.RelinquishOutputArgs{Basket: "b1", Output: *op}
+		good := serOK(SerializeRelinquishOutputArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeRelinquishOutputArgs(d)
+			return err
+		})
+	})
+
+	t.Run("RevealCounterpartyKeyLinkageArgs", func(t *testing.T) {
+		args := &wallet.RevealCounterpartyKeyLinkageArgs{
+			Counterparty:     pub,
+			Verifier:         pub,
+			Privileged:       util.BoolPtr(true),
+			PrivilegedReason: "r",
+		}
+		good := serOK(SerializeRevealCounterpartyKeyLinkageArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeRevealCounterpartyKeyLinkageArgs(d)
+			return err
+		})
+	})
+
+	t.Run("RevealCounterpartyKeyLinkageResult", func(t *testing.T) {
+		result := &wallet.RevealCounterpartyKeyLinkageResult{
+			Prover:                pub,
+			Verifier:              pub,
+			Counterparty:          pub,
+			RevelationTime:        "2023-01-01T00:00:00Z",
+			EncryptedLinkage:      []byte{1, 2, 3},
+			EncryptedLinkageProof: []byte{4, 5, 6},
+		}
+		good := serOK(SerializeRevealCounterpartyKeyLinkageResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeRevealCounterpartyKeyLinkageResult(d)
+			return err
+		})
+	})
+
+	t.Run("RevealSpecificKeyLinkageArgs", func(t *testing.T) {
+		args := &wallet.RevealSpecificKeyLinkageArgs{
+			Counterparty:     wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: pub},
+			Verifier:         pub,
+			ProtocolID:       wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "p"},
+			KeyID:            "k",
+			Privileged:       util.BoolPtr(true),
+			PrivilegedReason: "r",
+		}
+		good := serOK(SerializeRevealSpecificKeyLinkageArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeRevealSpecificKeyLinkageArgs(d)
+			return err
+		})
+	})
+
+	t.Run("RevealSpecificKeyLinkageResult", func(t *testing.T) {
+		result := &wallet.RevealSpecificKeyLinkageResult{
+			Prover:                pub,
+			Verifier:              pub,
+			Counterparty:          pub,
+			ProtocolID:            wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "p"},
+			KeyID:                 "k",
+			EncryptedLinkage:      []byte{1, 2, 3},
+			EncryptedLinkageProof: []byte{4, 5, 6},
+			ProofType:             1,
+		}
+		good := serOK(SerializeRevealSpecificKeyLinkageResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeRevealSpecificKeyLinkageResult(d)
+			return err
+		})
+	})
+
+	t.Run("SignActionArgs", func(t *testing.T) {
+		args := &wallet.SignActionArgs{
+			Spends: map[uint32]wallet.SignActionSpend{
+				0: {UnlockingScript: []byte{0x48, 0x30}, SequenceNumber: util.Uint32Ptr(1)},
+			},
+			Reference: []byte("ref"),
+			Options: &wallet.SignActionOptions{
+				AcceptDelayedBroadcast: util.BoolPtr(true),
+				ReturnTXIDOnly:         util.BoolPtr(false),
+				NoSend:                 util.BoolPtr(false),
+				SendWith:               []chainhash.Hash{hash},
+			},
+		}
+		good := serOK(SerializeSignActionArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeSignActionArgs(d)
+			return err
+		})
+	})
+
+	t.Run("SignActionResult", func(t *testing.T) {
+		result := &wallet.SignActionResult{
+			Txid: tu.GetByte32FromHexString(t, "8a552c995db3602e85bb9df911803897d1ea17ba5cdd198605d014be49db9f72"),
+			Tx:   []byte{1, 2, 3},
+			SendWithResults: []wallet.SendWithResult{
+				{Txid: tu.GetByte32FromHexString(t, "490c292a700c55d5e62379828d60bf6c61850fbb4d13382f52021d3796221981"), Status: wallet.ActionResultStatusSending},
+			},
+		}
+		good := serOK(SerializeSignActionResult(result))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeSignActionResult(d)
+			return err
+		})
+	})
+
+	t.Run("VerifyHMACArgs", func(t *testing.T) {
+		args := &wallet.VerifyHMACArgs{EncryptionArgs: encArgs, Data: []byte{1, 2, 3}, HMAC: [32]byte{9}}
+		good := serOK(SerializeVerifyHMACArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeVerifyHMACArgs(d)
+			return err
+		})
+	})
+
+	t.Run("VerifySignatureArgs", func(t *testing.T) {
+		args := &wallet.VerifySignatureArgs{
+			EncryptionArgs: encArgs,
+			ForSelf:        util.BoolPtr(true),
+			Signature:      sig,
+			Data:           []byte{5, 6, 7, 8},
+		}
+		good := serOK(SerializeVerifySignatureArgs(args))
+		runDeserializeSweep(t, good, func(d []byte) error {
+			_, err := DeserializeVerifySignatureArgs(d)
+			return err
+		})
+	})
+}

--- a/wallet/serializer/extra_coverage_test.go
+++ b/wallet/serializer/extra_coverage_test.go
@@ -1,0 +1,112 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func TestListActionsResultAllStatuses(t *testing.T) {
+	t.Parallel()
+
+	txid := tu.HashFromString(t, "b1f4d452814bba0ac422318083850b706d5f23ce232c789eefe5cbdcf2cc47de")
+	statuses := []wallet.ActionStatus{
+		wallet.ActionStatusCompleted,
+		wallet.ActionStatusUnprocessed,
+		wallet.ActionStatusSending,
+		wallet.ActionStatusUnproven,
+		wallet.ActionStatusUnsigned,
+		wallet.ActionStatusNoSend,
+		wallet.ActionStatusNonFinal,
+	}
+
+	result := &wallet.ListActionsResult{}
+	for i, s := range statuses {
+		result.Actions = append(result.Actions, wallet.Action{
+			Txid:        txid,
+			Satoshis:    int64(i),
+			Status:      s,
+			Description: "a",
+		})
+	}
+	result.TotalActions = uint32(len(result.Actions)) //nolint:gosec // G115 -- fixed small test slice length
+
+	data, err := SerializeListActionsResult(result)
+	require.NoError(t, err)
+
+	got, err := DeserializeListActionsResult(data)
+	require.NoError(t, err)
+	require.Len(t, got.Actions, len(statuses))
+	for i, s := range statuses {
+		assert.Equal(t, s, got.Actions[i].Status)
+	}
+}
+
+func TestSerializeProveCertificateResultInvalidBase64(t *testing.T) {
+	t.Parallel()
+
+	_, err := SerializeProveCertificateResult(&wallet.ProveCertificateResult{
+		KeyringForVerifier: map[string]string{"k": "!!!not-base64"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid keyring value base64")
+}
+
+func TestSerializeListCertificatesResultErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid keyring base64", func(t *testing.T) {
+		result := &wallet.ListCertificatesResult{
+			TotalCertificates: 1,
+			Certificates: []wallet.CertificateResult{{
+				Certificate: xtValidCertificate(t),
+				Keyring:     map[string]string{"k": "!!!not-base64"},
+			}},
+		}
+		_, err := SerializeListCertificatesResult(result)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid keyring value base64")
+	})
+
+	t.Run("inner certificate error", func(t *testing.T) {
+		cert := xtValidCertificate(t)
+		cert.Type = [32]byte{}
+		result := &wallet.ListCertificatesResult{
+			TotalCertificates: 1,
+			Certificates:      []wallet.CertificateResult{{Certificate: cert}},
+		}
+		_, err := SerializeListCertificatesResult(result)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cert type is empty")
+	})
+}
+
+func TestSerializeIdentityCertificateInvalidBase64(t *testing.T) {
+	t.Parallel()
+
+	idcert := xtValidIdentityCertificate(t)
+	idcert.PubliclyRevealedKeyring = map[string]string{"k": "!!!not-base64"}
+	_, err := SerializeIdentityCertificate(&idcert)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error decoding base64 value")
+}
+
+func TestDeserializeSignActionResultTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	result := &wallet.SignActionResult{
+		Txid: tu.GetByte32FromHexString(t, "8a552c995db3602e85bb9df911803897d1ea17ba5cdd198605d014be49db9f72"),
+		Tx:   []byte{1, 2, 3},
+	}
+	data, err := SerializeSignActionResult(result)
+	require.NoError(t, err)
+
+	// Appending an unexpected trailing byte makes CheckComplete fail.
+	_, err = DeserializeSignActionResult(append(data, 0x00))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error deserializing SignActionResult")
+}

--- a/wallet/serializer/fixtures_extra_test.go
+++ b/wallet/serializer/fixtures_extra_test.go
@@ -1,0 +1,57 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// xtPub returns a fresh, valid secp256k1 public key for use in tests.
+func xtPub(t *testing.T) *ec.PublicKey {
+	t.Helper()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err, "generating private key should not error")
+	return pk.PubKey()
+}
+
+// xtBadCounterparty returns a Counterparty of type Other whose public key is nil,
+// which makes encodeCounterparty (and every encodeKeyRelatedParams caller) fail.
+func xtBadCounterparty() wallet.Counterparty {
+	return wallet.Counterparty{Type: wallet.CounterpartyTypeOther, Counterparty: nil}
+}
+
+// xtValidCertificate builds a fully populated, serializable wallet.Certificate.
+func xtValidCertificate(t *testing.T) wallet.Certificate {
+	t.Helper()
+	pub := xtPub(t)
+	c := wallet.Certificate{
+		Subject:            pub,
+		Certifier:          pub,
+		RevocationOutpoint: tu.OutpointFromString(t, "a755810c21e17183ff6db6685f0de239fd3a0a3c0d4ba7773b0b0d1748541e2b.0"),
+		Signature:          newTestSignature(t),
+		Fields:             map[string]string{"field1": "value1"},
+	}
+	copy(c.Type[:], []byte("test-cert"))
+	copy(c.SerialNumber[:], []byte("serial-1"))
+	return c
+}
+
+// xtValidIdentityCertificate builds a fully populated wallet.IdentityCertificate.
+func xtValidIdentityCertificate(t *testing.T) wallet.IdentityCertificate {
+	t.Helper()
+	return wallet.IdentityCertificate{
+		Certificate: xtValidCertificate(t),
+		CertifierInfo: wallet.IdentityCertifier{
+			Name:        "Test Certifier",
+			IconUrl:     "https://example.com/icon.png",
+			Description: "desc",
+			Trust:       5,
+		},
+		PubliclyRevealedKeyring: map[string]string{"key1": "dmFsdWUx"},
+		DecryptedFields:         map[string]string{"field1": "decrypted1"},
+	}
+}

--- a/wallet/serializer/frame_extra_test.go
+++ b/wallet/serializer/frame_extra_test.go
@@ -1,0 +1,87 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+)
+
+func TestReadRequestFrameTruncated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty (missing call byte)", data: nil},
+		{name: "missing originator length", data: []byte{0x01}},
+		{
+			name: "truncated originator",
+			data: func() []byte {
+				w := util.NewWriter()
+				w.WriteByteValue(0x01) // call
+				w.WriteByteValue(0x05) // originator length says 5
+				w.WriteBytes([]byte{0x61, 0x62})
+				return w.Buf
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReadRequestFrame(tt.data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestReadResultFrameTruncated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty (missing error byte)", data: nil},
+		{name: "missing error message length", data: []byte{0x01}},
+		{
+			name: "truncated error message",
+			data: func() []byte {
+				w := util.NewWriter()
+				w.WriteByteValue(0x01) // error code
+				w.WriteVarInt(5)       // message length says 5
+				return w.Buf
+			}(),
+		},
+		{
+			name: "missing stack trace length",
+			data: func() []byte {
+				w := util.NewWriter()
+				w.WriteByteValue(0x01) // error code
+				w.WriteVarInt(2)       // message length
+				w.WriteBytes([]byte{0x61, 0x62})
+				return w.Buf
+			}(),
+		},
+		{
+			name: "truncated stack trace",
+			data: func() []byte {
+				w := util.NewWriter()
+				w.WriteByteValue(0x01) // error code
+				w.WriteVarInt(2)       // message length
+				w.WriteBytes([]byte{0x61, 0x62})
+				w.WriteVarInt(5) // stack length says 5
+				return w.Buf
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReadResultFrame(tt.data)
+			require.Error(t, err)
+		})
+	}
+}

--- a/wallet/serializer/serialize_errors_extra_test.go
+++ b/wallet/serializer/serialize_errors_extra_test.go
@@ -1,0 +1,325 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+	tu "github.com/bsv-blockchain/go-sdk/util/test_util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func TestSerializeKeyParamsEncodeErrors(t *testing.T) {
+	t.Parallel()
+
+	badEnc := wallet.EncryptionArgs{Counterparty: xtBadCounterparty()}
+
+	tests := []struct {
+		name string
+		fn   func() ([]byte, error)
+	}{
+		{"CreateHMACArgs", func() ([]byte, error) {
+			return SerializeCreateHMACArgs(&wallet.CreateHMACArgs{EncryptionArgs: badEnc})
+		}},
+		{"CreateSignatureArgs", func() ([]byte, error) {
+			return SerializeCreateSignatureArgs(&wallet.CreateSignatureArgs{EncryptionArgs: badEnc})
+		}},
+		{"DecryptArgs", func() ([]byte, error) {
+			return SerializeDecryptArgs(&wallet.DecryptArgs{EncryptionArgs: badEnc})
+		}},
+		{"EncryptArgs", func() ([]byte, error) {
+			return SerializeEncryptArgs(&wallet.EncryptArgs{EncryptionArgs: badEnc})
+		}},
+		{"VerifyHMACArgs", func() ([]byte, error) {
+			return SerializeVerifyHMACArgs(&wallet.VerifyHMACArgs{EncryptionArgs: badEnc})
+		}},
+		{"VerifySignatureArgs", func() ([]byte, error) {
+			return SerializeVerifySignatureArgs(&wallet.VerifySignatureArgs{EncryptionArgs: badEnc})
+		}},
+		{"GetPublicKeyArgs", func() ([]byte, error) {
+			return SerializeGetPublicKeyArgs(&wallet.GetPublicKeyArgs{EncryptionArgs: badEnc})
+		}},
+		{"RevealSpecificKeyLinkageArgs", func() ([]byte, error) {
+			return SerializeRevealSpecificKeyLinkageArgs(&wallet.RevealSpecificKeyLinkageArgs{Counterparty: xtBadCounterparty()})
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.fn()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "error encoding key params")
+		})
+	}
+}
+
+func TestSerializeResultCountMismatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ListActionsResult", func(t *testing.T) {
+		_, err := SerializeListActionsResult(&wallet.ListActionsResult{TotalActions: 5})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match")
+	})
+
+	t.Run("ListOutputsResult", func(t *testing.T) {
+		_, err := SerializeListOutputsResult(&wallet.ListOutputsResult{TotalOutputs: 3})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match")
+	})
+
+	t.Run("ListCertificatesResult", func(t *testing.T) {
+		_, err := SerializeListCertificatesResult(&wallet.ListCertificatesResult{TotalCertificates: 2})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match")
+	})
+
+	t.Run("DiscoverCertificatesResult", func(t *testing.T) {
+		_, err := SerializeDiscoverCertificatesResult(&wallet.DiscoverCertificatesResult{TotalCertificates: 2})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match")
+	})
+}
+
+func TestSerializeDiscoverCertificatesResultInnerError(t *testing.T) {
+	t.Parallel()
+
+	// An identity certificate whose base certificate has an empty type makes the
+	// inner SerializeCertificate call fail.
+	idcert := xtValidIdentityCertificate(t)
+	idcert.Type = [32]byte{}
+	_, err := SerializeDiscoverCertificatesResult(&wallet.DiscoverCertificatesResult{
+		TotalCertificates: 1,
+		Certificates:      []wallet.IdentityCertificate{idcert},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cert type is empty")
+}
+
+func TestSerializeProveCertificateArgsEmptyType(t *testing.T) {
+	t.Parallel()
+
+	args := &wallet.ProveCertificateArgs{Certificate: xtValidCertificate(t)}
+	args.Certificate.Type = [32]byte{}
+	_, err := SerializeProveCertificateArgs(args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate type is empty")
+}
+
+func TestSerializeRelinquishCertificateArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	nonZero := tu.GetByte32FromString("x")
+
+	t.Run("empty type", func(t *testing.T) {
+		_, err := SerializeRelinquishCertificateArgs(&wallet.RelinquishCertificateArgs{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "type is empty")
+	})
+
+	t.Run("empty serial number", func(t *testing.T) {
+		_, err := SerializeRelinquishCertificateArgs(&wallet.RelinquishCertificateArgs{Type: nonZero})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialNumber is empty")
+	})
+
+	t.Run("nil certifier", func(t *testing.T) {
+		_, err := SerializeRelinquishCertificateArgs(&wallet.RelinquishCertificateArgs{Type: nonZero, SerialNumber: nonZero})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "certifier is empty")
+	})
+}
+
+func TestSerializeDiscoverByIdentityKeyArgsNilKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := SerializeDiscoverByIdentityKeyArgs(&wallet.DiscoverByIdentityKeyArgs{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identityKey cannot be empty")
+}
+
+func TestSerializeInternalizeActionArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil payment remittance", func(t *testing.T) {
+		_, err := SerializeInternalizeActionArgs(&wallet.InternalizeActionArgs{
+			Outputs: []wallet.InternalizeOutput{{Protocol: wallet.InternalizeProtocolWalletPayment}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "payment remittance is required")
+	})
+
+	t.Run("nil insertion remittance", func(t *testing.T) {
+		_, err := SerializeInternalizeActionArgs(&wallet.InternalizeActionArgs{
+			Outputs: []wallet.InternalizeOutput{{Protocol: wallet.InternalizeProtocolBasketInsertion}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "insertion remittance is required")
+	})
+}
+
+func TestSerializeRevealCounterpartyKeyLinkageErrors(t *testing.T) {
+	t.Parallel()
+
+	pub := xtPub(t)
+
+	t.Run("args nil counterparty", func(t *testing.T) {
+		_, err := SerializeRevealCounterpartyKeyLinkageArgs(&wallet.RevealCounterpartyKeyLinkageArgs{Verifier: pub})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty public key is required")
+	})
+
+	t.Run("args nil verifier", func(t *testing.T) {
+		_, err := SerializeRevealCounterpartyKeyLinkageArgs(&wallet.RevealCounterpartyKeyLinkageArgs{Counterparty: pub})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "verifier public key is required")
+	})
+
+	t.Run("result nil prover", func(t *testing.T) {
+		_, err := SerializeRevealCounterpartyKeyLinkageResult(&wallet.RevealCounterpartyKeyLinkageResult{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "prover public key is required")
+	})
+
+	t.Run("result nil verifier", func(t *testing.T) {
+		_, err := SerializeRevealCounterpartyKeyLinkageResult(&wallet.RevealCounterpartyKeyLinkageResult{Prover: pub})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "verifier public key is required")
+	})
+
+	t.Run("result nil counterparty", func(t *testing.T) {
+		_, err := SerializeRevealCounterpartyKeyLinkageResult(&wallet.RevealCounterpartyKeyLinkageResult{Prover: pub, Verifier: pub})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty public key is required")
+	})
+}
+
+func TestSerializeRevealSpecificKeyLinkageErrors(t *testing.T) {
+	t.Parallel()
+
+	pub := xtPub(t)
+	validKey := wallet.RevealSpecificKeyLinkageArgs{
+		Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+		ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "p"},
+	}
+
+	t.Run("args nil verifier", func(t *testing.T) {
+		args := validKey
+		_, err := SerializeRevealSpecificKeyLinkageArgs(&args)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "verifier public key is required")
+	})
+
+	t.Run("result nil prover", func(t *testing.T) {
+		_, err := SerializeRevealSpecificKeyLinkageResult(&wallet.RevealSpecificKeyLinkageResult{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "prover public key is required")
+	})
+
+	t.Run("result nil verifier", func(t *testing.T) {
+		_, err := SerializeRevealSpecificKeyLinkageResult(&wallet.RevealSpecificKeyLinkageResult{Prover: pub})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "verifier public key is required")
+	})
+
+	t.Run("result nil counterparty", func(t *testing.T) {
+		_, err := SerializeRevealSpecificKeyLinkageResult(&wallet.RevealSpecificKeyLinkageResult{Prover: pub, Verifier: pub})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty public key is required")
+	})
+}
+
+func TestSerializeVerifySignatureArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	validEnc := wallet.EncryptionArgs{
+		ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "p"},
+		Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+	}
+
+	t.Run("nil signature", func(t *testing.T) {
+		_, err := SerializeVerifySignatureArgs(&wallet.VerifySignatureArgs{EncryptionArgs: validEnc, Data: []byte{1}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signature cannot be nil")
+	})
+
+	t.Run("invalid data or hash", func(t *testing.T) {
+		_, err := SerializeVerifySignatureArgs(&wallet.VerifySignatureArgs{
+			EncryptionArgs:       validEnc,
+			Signature:            newTestSignature(t),
+			HashToDirectlyVerify: []byte{1, 2, 3}, // wrong size, and no Data
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid data or hash")
+	})
+}
+
+func TestSerializeListActionsArgsLimitExceeds(t *testing.T) {
+	t.Parallel()
+
+	_, err := SerializeListActionsArgs(&wallet.ListActionsArgs{Limit: util.Uint32Ptr(wallet.MaxActionsLimit + 1)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit exceeds maximum")
+}
+
+func TestSerializeAcquireCertificateArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	pub := xtPub(t)
+	op := tu.OutpointFromString(t, "a755810c21e17183ff6db6685f0de239fd3a0a3c0d4ba7773b0b0d1748541e2b.0")
+
+	t.Run("invalid acquisition protocol", func(t *testing.T) {
+		_, err := SerializeAcquireCertificateArgs(&wallet.AcquireCertificateArgs{
+			Certifier:           pub,
+			AcquisitionProtocol: wallet.AcquisitionProtocol("bogus"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid acquisition protocol")
+	})
+
+	t.Run("direct nil serial number", func(t *testing.T) {
+		_, err := SerializeAcquireCertificateArgs(&wallet.AcquireCertificateArgs{
+			Certifier:           pub,
+			AcquisitionProtocol: wallet.AcquisitionProtocolDirect,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialNumber is empty")
+	})
+
+	t.Run("nil keyring revealer", func(t *testing.T) {
+		_, err := SerializeAcquireCertificateArgs(&wallet.AcquireCertificateArgs{
+			Certifier:           pub,
+			AcquisitionProtocol: wallet.AcquisitionProtocolDirect,
+			SerialNumber:        &wallet.SerialNumber{1},
+			RevocationOutpoint:  op,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "keyringRevealer cannot be nil")
+	})
+
+	t.Run("keyring revealer pubkey nil when not certifier", func(t *testing.T) {
+		_, err := SerializeAcquireCertificateArgs(&wallet.AcquireCertificateArgs{
+			Certifier:           pub,
+			AcquisitionProtocol: wallet.AcquisitionProtocolDirect,
+			SerialNumber:        &wallet.SerialNumber{1},
+			RevocationOutpoint:  op,
+			KeyringRevealer:     &wallet.KeyringRevealer{Certifier: false},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "keyringRevealer PubKey cannot be nil if not certifier")
+	})
+}
+
+func TestSerializeCreateActionResultInvalidSendWithStatus(t *testing.T) {
+	t.Parallel()
+
+	_, err := SerializeCreateActionResult(&wallet.CreateActionResult{
+		SendWithResults: []wallet.SendWithResult{
+			{Txid: tu.GetByte32FromHexString(t, "8a552c995db3602e85bb9df911803897d1ea17ba5cdd198605d014be49db9f72"), Status: wallet.ActionResultStatus("bogus")},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sendWith results")
+}

--- a/wallet/serializer/serializer_helpers_extra_test.go
+++ b/wallet/serializer/serializer_helpers_extra_test.go
@@ -1,0 +1,136 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func TestEncodeCounterpartyErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil pubkey for type other", func(t *testing.T) {
+		w := util.NewWriter()
+		err := encodeCounterparty(w, xtBadCounterparty())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "counterparty is nil for type other")
+	})
+
+	t.Run("unknown counterparty type", func(t *testing.T) {
+		w := util.NewWriter()
+		err := encodeCounterparty(w, wallet.Counterparty{Type: wallet.CounterpartyType(99)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown counterparty type")
+	})
+}
+
+func TestEncodeKeyRelatedParamsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := encodeKeyRelatedParams(KeyRelatedParams{
+		ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "p"},
+		Counterparty: xtBadCounterparty(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "counterparty is nil for type other")
+}
+
+func TestDecodeCounterpartyInvalidPubKey(t *testing.T) {
+	t.Parallel()
+
+	// Flag byte 0x01 is not one of the special codes (0/11/12), so it is parsed
+	// as the first byte of a compressed public key; 0x01 is an invalid magic.
+	data := append([]byte{0x01}, make([]byte, 32)...)
+	r := util.NewReaderHoldError(data)
+	_, err := decodeCounterparty(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid counterparty bytes")
+}
+
+func TestDecodeProtocolTruncated(t *testing.T) {
+	t.Parallel()
+
+	r := util.NewReaderHoldError(nil)
+	_, err := decodeProtocol(r)
+	require.Error(t, err)
+}
+
+func TestDecodeKeyRelatedParamsErrors(t *testing.T) {
+	t.Parallel()
+
+	validProtocol := encodeProtocol(wallet.Protocol{SecurityLevel: wallet.SecurityLevelSilent, Protocol: "p"})
+
+	t.Run("protocol read error", func(t *testing.T) {
+		r := util.NewReaderHoldError(nil)
+		_, err := decodeKeyRelatedParams(r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error decoding protocol")
+	})
+
+	t.Run("counterparty read error", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteBytes(validProtocol)
+		w.WriteString("k")
+		w.WriteByteValue(0x01) // invalid pubkey magic for type-other counterparty
+		w.WriteBytes(make([]byte, 32))
+		r := util.NewReaderHoldError(w.Buf)
+		_, err := decodeKeyRelatedParams(r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error decoding counterparty")
+	})
+
+	t.Run("privileged params read error", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteBytes(validProtocol)
+		w.WriteString("k")
+		w.WriteByteValue(counterPartyTypeSelfCode) // valid counterparty, then buffer ends
+		r := util.NewReaderHoldError(w.Buf)
+		_, err := decodeKeyRelatedParams(r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error decoding key params")
+	})
+}
+
+func TestDecodeOutpointsCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty data returns nil", func(t *testing.T) {
+		got, err := decodeOutpoints(nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("negative-one count returns nil", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(util.NegativeOne)
+		got, err := decodeOutpoints(w.Buf)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("truncated count", func(t *testing.T) {
+		_, err := decodeOutpoints([]byte{0xFF})
+		require.Error(t, err)
+	})
+
+	t.Run("truncated txid", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(1)
+		w.WriteBytes([]byte{0x01, 0x02}) // fewer than 32 bytes
+		_, err := decodeOutpoints(w.Buf)
+		require.Error(t, err)
+	})
+
+	t.Run("truncated output index", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(1)
+		w.WriteBytes(make([]byte, 32)) // valid txid length
+		w.WriteByteValue(0xFF)         // varint prefix demanding more bytes
+		_, err := decodeOutpoints(w.Buf)
+		require.Error(t, err)
+	})
+}

--- a/wallet/serializer/status_extra_test.go
+++ b/wallet/serializer/status_extra_test.go
@@ -1,0 +1,116 @@
+package serializer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/util"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// txidStatusFixture returns a deterministic 32-byte txid filled with b.
+func txidStatusFixture(b byte) chainhash.Hash {
+	var h chainhash.Hash
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+func TestWriteReadTxidSliceWithStatusRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		results []wallet.SendWithResult
+		want    []wallet.SendWithResult // nil when the slice is empty (both encode as count 0)
+	}{
+		"nil slice":   {results: nil, want: nil},
+		"empty slice": {results: []wallet.SendWithResult{}, want: nil},
+		"single unproven": {
+			results: []wallet.SendWithResult{{Txid: txidStatusFixture(0x01), Status: wallet.ActionResultStatusUnproven}},
+			want:    []wallet.SendWithResult{{Txid: txidStatusFixture(0x01), Status: wallet.ActionResultStatusUnproven}},
+		},
+		"all statuses": {
+			results: []wallet.SendWithResult{
+				{Txid: txidStatusFixture(0x01), Status: wallet.ActionResultStatusUnproven},
+				{Txid: txidStatusFixture(0x02), Status: wallet.ActionResultStatusSending},
+				{Txid: txidStatusFixture(0x03), Status: wallet.ActionResultStatusFailed},
+			},
+			want: []wallet.SendWithResult{
+				{Txid: txidStatusFixture(0x01), Status: wallet.ActionResultStatusUnproven},
+				{Txid: txidStatusFixture(0x02), Status: wallet.ActionResultStatusSending},
+				{Txid: txidStatusFixture(0x03), Status: wallet.ActionResultStatusFailed},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := util.NewWriter()
+			require.NoError(t, writeTxidSliceWithStatus(w, tc.results))
+
+			r := util.NewReader(w.Buf)
+			got, err := readTxidSliceWithStatus(r)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWriteTxidSliceWithStatusInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	w := util.NewWriter()
+	err := writeTxidSliceWithStatus(w, []wallet.SendWithResult{
+		{Txid: txidStatusFixture(0x01), Status: wallet.ActionResultStatus("bogus")},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid status")
+}
+
+func TestReadTxidSliceWithStatusInvalidStatusCode(t *testing.T) {
+	t.Parallel()
+
+	// count=1, valid 32-byte txid, then an out-of-range status byte.
+	w := util.NewWriter()
+	w.WriteVarInt(1)
+	h := txidStatusFixture(0x01)
+	w.WriteBytes(h[:])
+	w.WriteByteValue(0x09)
+
+	r := util.NewReader(w.Buf)
+	_, err := readTxidSliceWithStatus(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid status code")
+}
+
+func TestReadTxidSliceWithStatusTruncated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("truncated count", func(t *testing.T) {
+		r := util.NewReader(nil)
+		_, err := readTxidSliceWithStatus(r)
+		require.Error(t, err)
+	})
+
+	t.Run("truncated txid", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(1)
+		w.WriteBytes([]byte{0x01, 0x02}) // fewer than the 32 txid bytes claimed
+		r := util.NewReader(w.Buf)
+		_, err := readTxidSliceWithStatus(r)
+		require.Error(t, err)
+	})
+
+	t.Run("missing status byte", func(t *testing.T) {
+		w := util.NewWriter()
+		w.WriteVarInt(1)
+		h := txidStatusFixture(0x01)
+		w.WriteBytes(h[:]) // txid present but no trailing status byte
+		r := util.NewReader(w.Buf)
+		_, err := readTxidSliceWithStatus(r)
+		require.Error(t, err)
+	})
+}

--- a/wallet/substrates/http_wallet_json_extra_test.go
+++ b/wallet/substrates/http_wallet_json_extra_test.go
@@ -1,6 +1,7 @@
 package substrates
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -32,4 +33,88 @@ func TestHTTPWalletJSONGetPublicKey(t *testing.T) {
 	result, err := client.GetPublicKey(t.Context(), wallet.GetPublicKeyArgs{IdentityKey: true})
 	require.NoError(t, err)
 	require.NotNil(t, result.PublicKey)
+}
+
+// TestHTTPWalletJSONAPIErrorBranches drives every wallet method against a server
+// that always returns HTTP 500, exercising each method's "api error" return path.
+func TestHTTPWalletJSONAPIErrorBranches(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer ts.Close()
+
+	client := NewHTTPWalletJSON("", ts.URL, nil)
+	ctx := context.Background()
+
+	privKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	sig, err := privKey.Sign(make([]byte, 32))
+	require.NoError(t, err)
+
+	checks := map[string]func() error{
+		"CreateAction":      func() error { _, e := client.CreateAction(ctx, wallet.CreateActionArgs{}); return e },
+		"SignAction":        func() error { _, e := client.SignAction(ctx, &wallet.SignActionArgs{}); return e },
+		"AbortAction":       func() error { _, e := client.AbortAction(ctx, wallet.AbortActionArgs{}); return e },
+		"ListActions":       func() error { _, e := client.ListActions(ctx, wallet.ListActionsArgs{}); return e },
+		"InternalizeAction": func() error { _, e := client.InternalizeAction(ctx, wallet.InternalizeActionArgs{}); return e },
+		"ListOutputs":       func() error { _, e := client.ListOutputs(ctx, wallet.ListOutputsArgs{}); return e },
+		"RelinquishOutput":  func() error { _, e := client.RelinquishOutput(ctx, &wallet.RelinquishOutputArgs{}); return e },
+		"GetPublicKey":      func() error { _, e := client.GetPublicKey(ctx, wallet.GetPublicKeyArgs{IdentityKey: true}); return e },
+		"RevealCounterpartyKeyLinkage": func() error {
+			_, e := client.RevealCounterpartyKeyLinkage(ctx, wallet.RevealCounterpartyKeyLinkageArgs{})
+			return e
+		},
+		"RevealSpecificKeyLinkage": func() error {
+			_, e := client.RevealSpecificKeyLinkage(ctx, wallet.RevealSpecificKeyLinkageArgs{})
+			return e
+		},
+		"Encrypt":    func() error { _, e := client.Encrypt(ctx, wallet.EncryptArgs{}); return e },
+		"Decrypt":    func() error { _, e := client.Decrypt(ctx, wallet.DecryptArgs{}); return e },
+		"CreateHMAC": func() error { _, e := client.CreateHMAC(ctx, wallet.CreateHMACArgs{}); return e },
+		"VerifyHMAC": func() error { _, e := client.VerifyHMAC(ctx, wallet.VerifyHMACArgs{}); return e },
+		"CreateSignature": func() error {
+			_, e := client.CreateSignature(ctx, wallet.CreateSignatureArgs{})
+			return e
+		},
+		"VerifySignature": func() error {
+			_, e := client.VerifySignature(ctx, wallet.VerifySignatureArgs{Signature: sig})
+			return e
+		},
+		"AcquireCertificate": func() error {
+			_, e := client.AcquireCertificate(ctx, &wallet.AcquireCertificateArgs{})
+			return e
+		},
+		"ListCertificates": func() error { _, e := client.ListCertificates(ctx, wallet.ListCertificatesArgs{}); return e },
+		"ProveCertificate": func() error {
+			_, e := client.ProveCertificate(ctx, &wallet.ProveCertificateArgs{})
+			return e
+		},
+		"RelinquishCertificate": func() error {
+			_, e := client.RelinquishCertificate(ctx, &wallet.RelinquishCertificateArgs{})
+			return e
+		},
+		"DiscoverByIdentityKey": func() error {
+			_, e := client.DiscoverByIdentityKey(ctx, &wallet.DiscoverByIdentityKeyArgs{})
+			return e
+		},
+		"DiscoverByAttributes": func() error {
+			_, e := client.DiscoverByAttributes(ctx, wallet.DiscoverByAttributesArgs{})
+			return e
+		},
+		"IsAuthenticated":       func() error { _, e := client.IsAuthenticated(ctx, nil); return e },
+		"WaitForAuthentication": func() error { _, e := client.WaitForAuthentication(ctx, nil); return e },
+		"GetHeight":             func() error { _, e := client.GetHeight(ctx, nil); return e },
+		"GetHeaderForHeight":    func() error { _, e := client.GetHeaderForHeight(ctx, wallet.GetHeaderArgs{}); return e },
+		"GetNetwork":            func() error { _, e := client.GetNetwork(ctx, nil); return e },
+		"GetVersion":            func() error { _, e := client.GetVersion(ctx, nil); return e },
+	}
+
+	for name, fn := range checks {
+		t.Run(name, func(t *testing.T) {
+			err := fn()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "500")
+		})
+	}
 }

--- a/wallet/substrates/http_wallet_wire_test.go
+++ b/wallet/substrates/http_wallet_wire_test.go
@@ -140,3 +140,16 @@ func TestTransmitToWallet_HTTPErrors(t *testing.T) {
 	require.Error(t, err, "expected HTTP error")
 	require.EqualError(t, err, "HTTP request failed with status: 500 Internal Server Error", "error message mismatch")
 }
+
+func TestTransmitToWallet_DoError(t *testing.T) {
+	// An unsupported URL scheme makes httpClient.Do fail without any network access.
+	message := []byte{
+		byte(CallCreateAction),            // call code
+		0,                                 // no originator
+		'p', 'a', 'y', 'l', 'o', 'a', 'd', // payload
+	}
+
+	wire := NewHTTPWalletWire("app.test", "htp://invalid-scheme", &http.Client{})
+	_, err := wire.TransmitToWallet(t.Context(), message)
+	require.Error(t, err, "expected transport error")
+}

--- a/wallet/substrates/wallet_wire_extra_test.go
+++ b/wallet/substrates/wallet_wire_extra_test.go
@@ -1,0 +1,433 @@
+package substrates_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-sdk/wallet/serializer"
+	"github.com/bsv-blockchain/go-sdk/wallet/substrates"
+)
+
+// frameForCall builds a request frame for the given call with the provided params.
+func frameForCall(call substrates.Call, params []byte) []byte {
+	return serializer.WriteRequestFrame(serializer.RequestFrame{
+		Call:   byte(call),
+		Params: params,
+	})
+}
+
+// TestProcessorDeserializeArgErrors feeds malformed params to each call so the
+// per-method "failed to deserialize" branch is exercised in the processor.
+func TestProcessorDeserializeArgErrors(t *testing.T) {
+	tw := wallet.NewTestWalletForRandomKey(t)
+	processor := substrates.NewWalletWireProcessor(tw)
+
+	// badParams is a single 0xFF byte: as a varint prefix it demands 8 more
+	// bytes that are not present, so the first length-prefixed read fails; for
+	// methods that read a leading flag byte, the subsequent read then fails.
+	badParams := []byte{0xFF}
+
+	calls := map[string]substrates.Call{
+		"CreateAction":                 substrates.CallCreateAction,
+		"SignAction":                   substrates.CallSignAction,
+		"ListActions":                  substrates.CallListActions,
+		"InternalizeAction":            substrates.CallInternalizeAction,
+		"ListOutputs":                  substrates.CallListOutputs,
+		"RelinquishOutput":             substrates.CallRelinquishOutput,
+		"GetPublicKey":                 substrates.CallGetPublicKey,
+		"RevealCounterpartyKeyLinkage": substrates.CallRevealCounterpartyKeyLinkage,
+		"RevealSpecificKeyLinkage":     substrates.CallRevealSpecificKeyLinkage,
+		"Encrypt":                      substrates.CallEncrypt,
+		"Decrypt":                      substrates.CallDecrypt,
+		"CreateHMAC":                   substrates.CallCreateHMAC,
+		"VerifyHMAC":                   substrates.CallVerifyHMAC,
+		"CreateSignature":              substrates.CallCreateSignature,
+		"VerifySignature":              substrates.CallVerifySignature,
+		"AcquireCertificate":           substrates.CallAcquireCertificate,
+		"ListCertificates":             substrates.CallListCertificates,
+		"ProveCertificate":             substrates.CallProveCertificate,
+		"RelinquishCertificate":        substrates.CallRelinquishCertificate,
+		"DiscoverByIdentityKey":        substrates.CallDiscoverByIdentityKey,
+		"DiscoverByAttributes":         substrates.CallDiscoverByAttributes,
+		"GetHeaderForHeight":           substrates.CallGetHeaderForHeight,
+	}
+
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			_, err := processor.TransmitToWallet(context.Background(), frameForCall(call, badParams))
+			require.Error(t, err)
+		})
+	}
+}
+
+// ---- Transceiver serialize-arg error branches ----
+//
+// A Counterparty of type "other" with a nil public key cannot be serialized,
+// so the transceiver's "failed to serialize" branch is exercised before any
+// transmit happens.
+
+func badEncryptionArgs() wallet.EncryptionArgs {
+	return wallet.EncryptionArgs{
+		ProtocolID: wallet.Protocol{
+			SecurityLevel: wallet.SecurityLevelEveryApp,
+			Protocol:      "testprotocol",
+		},
+		KeyID: "k1",
+		Counterparty: wallet.Counterparty{
+			Type: wallet.CounterpartyTypeOther, // nil Counterparty key -> serialize error
+		},
+	}
+}
+
+func TestTransceiverSerializeErrors(t *testing.T) {
+	_, transceiver := buildTransceiverPair(t)
+	ctx := context.Background()
+
+	t.Run("GetPublicKey", func(t *testing.T) {
+		_, err := transceiver.GetPublicKey(ctx, wallet.GetPublicKeyArgs{
+			EncryptionArgs: badEncryptionArgs(),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("Encrypt", func(t *testing.T) {
+		_, err := transceiver.Encrypt(ctx, wallet.EncryptArgs{
+			EncryptionArgs: badEncryptionArgs(),
+			Plaintext:      []byte("x"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("Decrypt", func(t *testing.T) {
+		_, err := transceiver.Decrypt(ctx, wallet.DecryptArgs{
+			EncryptionArgs: badEncryptionArgs(),
+			Ciphertext:     []byte("x"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("CreateHMAC", func(t *testing.T) {
+		_, err := transceiver.CreateHMAC(ctx, wallet.CreateHMACArgs{
+			EncryptionArgs: badEncryptionArgs(),
+			Data:           []byte("x"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("VerifyHMAC", func(t *testing.T) {
+		_, err := transceiver.VerifyHMAC(ctx, wallet.VerifyHMACArgs{
+			EncryptionArgs: badEncryptionArgs(),
+			Data:           []byte("x"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("CreateSignature", func(t *testing.T) {
+		_, err := transceiver.CreateSignature(ctx, wallet.CreateSignatureArgs{
+			EncryptionArgs: badEncryptionArgs(),
+			Data:           []byte("x"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("VerifySignature", func(t *testing.T) {
+		_, err := transceiver.VerifySignature(ctx, wallet.VerifySignatureArgs{
+			EncryptionArgs: badEncryptionArgs(),
+			Data:           []byte("x"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("RevealSpecificKeyLinkage", func(t *testing.T) {
+		verifierKey, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+		_, err = transceiver.RevealSpecificKeyLinkage(ctx, wallet.RevealSpecificKeyLinkageArgs{
+			Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeOther}, // nil key -> serialize error
+			ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:        "k1",
+			Verifier:     verifierKey.PubKey(),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("RevealCounterpartyKeyLinkage", func(t *testing.T) {
+		// nil Counterparty public key -> serialize error
+		_, err := transceiver.RevealCounterpartyKeyLinkage(ctx, wallet.RevealCounterpartyKeyLinkageArgs{}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("ListActions", func(t *testing.T) {
+		_, err := transceiver.ListActions(ctx, wallet.ListActionsArgs{
+			LabelQueryMode: wallet.QueryMode("bogus"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("InternalizeAction", func(t *testing.T) {
+		_, err := transceiver.InternalizeAction(ctx, wallet.InternalizeActionArgs{
+			Tx:          []byte{0x01},
+			Description: "d",
+			Outputs: []wallet.InternalizeOutput{
+				{Protocol: wallet.InternalizeProtocolWalletPayment}, // nil PaymentRemittance -> error
+			},
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("AcquireCertificate", func(t *testing.T) {
+		certifierKey, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+		_, err = transceiver.AcquireCertificate(ctx, wallet.AcquireCertificateArgs{
+			Certifier:           certifierKey.PubKey(),
+			AcquisitionProtocol: wallet.AcquisitionProtocol("bogus"),
+		}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("ProveCertificate", func(t *testing.T) {
+		// zero-value certificate type -> "certificate type is empty"
+		_, err := transceiver.ProveCertificate(ctx, wallet.ProveCertificateArgs{}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("RelinquishCertificate", func(t *testing.T) {
+		// zero-value type -> "type is empty"
+		_, err := transceiver.RelinquishCertificate(ctx, wallet.RelinquishCertificateArgs{}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+
+	t.Run("DiscoverByIdentityKey", func(t *testing.T) {
+		// nil IdentityKey -> "identityKey cannot be empty"
+		_, err := transceiver.DiscoverByIdentityKey(ctx, wallet.DiscoverByIdentityKeyArgs{}, testAppOriginator)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serialize")
+	})
+}
+
+// ---- Transceiver transmit / processor wallet-error branches ----
+//
+// These drive the remaining per-method transmit-error branch in the
+// transceiver together with the wallet-error branch in the processor by
+// having the backing wallet return an error for a successfully-serialized call.
+
+func TestTransceiverWalletErrorEncrypt(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.Encrypt(context.Background(), wallet.EncryptArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Plaintext: []byte("hello"),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorDecrypt(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.Decrypt(context.Background(), wallet.DecryptArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Ciphertext: []byte("hello"),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorCreateHMAC(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.CreateHMAC(context.Background(), wallet.CreateHMACArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Data: []byte("data"),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorVerifyHMAC(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.VerifyHMAC(context.Background(), wallet.VerifyHMACArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Data: []byte("data"),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorCreateSignature(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.CreateSignature(context.Background(), wallet.CreateSignatureArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Data: []byte("data"),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorVerifySignature(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	privKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	sig, err := privKey.Sign([]byte("data"))
+	require.NoError(t, err)
+	_, err = transceiver.VerifySignature(context.Background(), wallet.VerifySignatureArgs{
+		EncryptionArgs: wallet.EncryptionArgs{
+			ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+			KeyID:      "k1",
+		},
+		Data:      []byte("data"),
+		Signature: sig,
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorRevealCounterpartyKeyLinkage(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	counterpartyKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	_, err = transceiver.RevealCounterpartyKeyLinkage(context.Background(), wallet.RevealCounterpartyKeyLinkageArgs{
+		Counterparty: counterpartyKey.PubKey(),
+		Verifier:     verifierKey.PubKey(),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorRevealSpecificKeyLinkage(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	counterpartyKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	_, err = transceiver.RevealSpecificKeyLinkage(context.Background(), wallet.RevealSpecificKeyLinkageArgs{
+		Counterparty: wallet.Counterparty{
+			Type:         wallet.CounterpartyTypeOther,
+			Counterparty: counterpartyKey.PubKey(),
+		},
+		Verifier:   verifierKey.PubKey(),
+		ProtocolID: wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+		KeyID:      "k1",
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorAcquireCertificate(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	certifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	_, err = transceiver.AcquireCertificate(context.Background(), wallet.AcquireCertificateArgs{
+		Certifier:           certifierKey.PubKey(),
+		AcquisitionProtocol: wallet.AcquisitionProtocolIssuance,
+		CertifierUrl:        "https://certifier.example.com",
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorProveCertificate(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	certifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	verifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	ct, _ := wallet.CertificateTypeFromString("provecert12345678901234567890123")
+	var serial wallet.SerialNumber
+	copy(serial[:], []byte("serial1234567890123456789012345"))
+	_, err = transceiver.ProveCertificate(context.Background(), wallet.ProveCertificateArgs{
+		Certificate: wallet.Certificate{
+			Type:               ct,
+			Subject:            certifierKey.PubKey(),
+			Certifier:          certifierKey.PubKey(),
+			SerialNumber:       serial,
+			RevocationOutpoint: &transaction.Outpoint{},
+		},
+		Verifier: verifierKey.PubKey(),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorRelinquishCertificate(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	certifierKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	ct, _ := wallet.CertificateTypeFromString("relinquishcert12345678901234567")
+	var serial wallet.SerialNumber
+	copy(serial[:], []byte("serial1234567890123456789012345"))
+	_, err = transceiver.RelinquishCertificate(context.Background(), wallet.RelinquishCertificateArgs{
+		Type:         ct,
+		SerialNumber: serial,
+		Certifier:    certifierKey.PubKey(),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorDiscoverByIdentityKey(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	privKey, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	_, err = transceiver.DiscoverByIdentityKey(context.Background(), wallet.DiscoverByIdentityKeyArgs{
+		IdentityKey: privKey.PubKey(),
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorDiscoverByAttributes(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.DiscoverByAttributes(context.Background(), wallet.DiscoverByAttributesArgs{
+		Attributes: map[string]string{"key": "val"},
+	}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorWaitForAuthentication(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.WaitForAuthentication(context.Background(), nil, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}
+
+func TestTransceiverWalletErrorGetHeaderForHeight(t *testing.T) {
+	transceiver := buildPairWithWalletError(t)
+	_, err := transceiver.GetHeaderForHeight(context.Background(), wallet.GetHeaderArgs{Height: 100}, "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testWalletErrMsg)
+}

--- a/wallet/wallet_extra_test.go
+++ b/wallet/wallet_extra_test.go
@@ -1,0 +1,104 @@
+package wallet_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+func TestNewWalletVariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil private key produces anyone wallet", func(t *testing.T) {
+		t.Parallel()
+		w, err := wallet.NewWallet(nil)
+		require.NoError(t, err)
+		require.NotNil(t, w)
+	})
+
+	t.Run("valid private key", func(t *testing.T) {
+		t.Parallel()
+		pk, err := ec.NewPrivateKey()
+		require.NoError(t, err)
+		w, err := wallet.NewWallet(pk)
+		require.NoError(t, err)
+		require.NotNil(t, w)
+	})
+}
+
+func TestCertificateTypeFromBase64TooLong(t *testing.T) {
+	t.Parallel()
+	// 33 bytes base64-encoded exceeds the 32-byte certificate type limit.
+	tooLong := base64.StdEncoding.EncodeToString(make([]byte, 33))
+	_, err := wallet.CertificateTypeFromBase64(tooLong)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "longer then 32 bytes")
+}
+
+func TestToIdentityKeyFromPrivateKey(t *testing.T) {
+	t.Parallel()
+	privBytes := make([]byte, 32)
+	for i := range privBytes {
+		privBytes[i] = byte(i + 1)
+	}
+	pk, _ := ec.PrivateKeyFromBytes(privBytes)
+
+	t.Run("valid PrivHex", func(t *testing.T) {
+		t.Parallel()
+		pub, err := wallet.ToIdentityKey(wallet.PrivHex(hex.EncodeToString(privBytes)))
+		require.NoError(t, err)
+		assert.Equal(t, pk.PubKey(), pub)
+	})
+
+	t.Run("valid *ec.PrivateKey", func(t *testing.T) {
+		t.Parallel()
+		pub, err := wallet.ToIdentityKey(pk)
+		require.NoError(t, err)
+		assert.Equal(t, pk.PubKey(), pub)
+	})
+
+	t.Run("nil *ec.PrivateKey", func(t *testing.T) {
+		t.Parallel()
+		var nilPK *ec.PrivateKey
+		_, err := wallet.ToIdentityKey(nilPK)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "private key cannot be nil to produce identity key")
+	})
+}
+
+func TestCompletedProtoWalletVerifySignature(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pk, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	w, err := wallet.NewCompletedProtoWallet(pk)
+	require.NoError(t, err)
+
+	encArgs := wallet.EncryptionArgs{
+		ProtocolID:   wallet.Protocol{SecurityLevel: wallet.SecurityLevelEveryApp, Protocol: "testprotocol"},
+		KeyID:        "k1",
+		Counterparty: wallet.Counterparty{Type: wallet.CounterpartyTypeSelf},
+	}
+	data := []byte("message to sign")
+
+	created, err := w.CreateSignature(ctx, wallet.CreateSignatureArgs{
+		EncryptionArgs: encArgs,
+		Data:           data,
+	}, "app")
+	require.NoError(t, err)
+
+	verified, err := w.VerifySignature(ctx, wallet.VerifySignatureArgs{
+		EncryptionArgs: encArgs,
+		Data:           data,
+		Signature:      created.Signature,
+	}, "app")
+	require.NoError(t, err)
+	assert.True(t, verified.Valid)
+}


### PR DESCRIPTION
## Summary

Raises reported test coverage from **~77%** into the low‑90s by (1) correcting Codecov so it stops counting non‑production code that can never be covered, and (2) adding focused tests for previously‑uncovered error/branch paths across the SDK.

**Production code is unchanged** — this PR is test‑only plus coverage configuration.

## Motivation

Codecov reported ~77%. Two issues held it down, independent of real test quality:

1. **`docs/` was counted as 0% forever.** The `docs/` tree is 38 standalone `package main` example programs — no tests, no `Example` functions — so `-coverpkg` instruments ~1,400 lines that can only ever report 0%. Sonar already excludes `docs/**` (`sonar-project.properties`); Codecov never got the same rule.
2. **Shared test infrastructure was counted as production.** Helpers such as `registry.MockRegistry`, `wallet.TestWallet`, `wallet/testcertificates`, `util/test_util`, and `testdata` fixtures must live in non‑`_test.go` files so they can be imported across packages' tests — which means they get instrumented despite being test‑only code. Sonar excludes these via its `**test**` glob; Codecov did not.

## Changes

### Coverage configuration (mirrors existing Sonar policy)
- `codecov.yml` — ignore `docs/**` and the shared test‑infra paths (`**/testdata/**`, `**/test_util/**`, `**/test_cert_util/**`, `**/testcertificates/**`, `**/test_wallet.go`, `**/test_logger.go`, `**/mock.go`).
- `.github/env/90-project.env` — same exclusions for the internal coverage tool, keeping the two providers aligned.

### New tests (48 files; production code frozen)
Table‑driven tests targeting uncovered error paths, branches, and round‑trip (de)serialization. Per‑package statement coverage (`go test -cover`):

| Package | Before | After |
|---|--------|-------|
| wallet | 88.2% | **95.2%** |
| transaction | 90.2% | **97.5%** |
| auth (tree) | 86.6% | **94.3%** |
| primitives | 96.8% | **97.7%** |
| script | 93.8% | **95.8%** |
| identity | 82.6% | **93.5%** |
| util | 96.2% | **99.4%** |
| overlay / compat / kvstore / storage | — | all lifted |

Roughly **900+ statements** moved from uncovered to covered, concentrated in the highest‑impact packages (`transaction/beef.go`, `auth/peer.go`, the wallet serializers/substrates, `wallet/encoding_json.go`, etc.).

## Testing

The full `fix-all` pipeline passes:
- `magex format:fix` and `go-pre-commit` (fumpt / eof / whitespace / mod‑tidy / gitleaks) — clean.
- `magex lint` (golangci‑lint 2.13.2, 53 linters + `go vet`) — **0 issues**.
- `magex test:race` (full suite, `-race`) — **all packages pass**. One data race in a new test (parallel subtests sharing a scratch buffer) was found and fixed.

## Notes

- No production `.go` file is modified.
- Remaining sub‑100% branches are intentionally left uncovered where they are genuinely unreachable defensive code (errors guarded by upstream validation, `log.Fatal`/`rand.Read` failure paths, `json.Marshal` of always‑valid data, etc.).
