### PR TITLE
fix(spv): verify scripts under Chronicle rules

### DIFF
--- a/spv/verify.go
+++ b/spv/verify.go
@@ -69,10 +69,14 @@ func Verify(ctx context.Context, t *transaction.Transaction,
 				}
 			}
 
+			// Chronicle is active on BSV mainnet, so scripts are verified
+			// under post-Chronicle rules (re-enabled opcodes such as OP_2MUL).
+			// UTXOAfterChronicle requires UTXOAfterGenesis.
 			if err := interpreter.NewEngine().Execute(
 				interpreter.WithTx(tx, vin, sourceOutput),
 				interpreter.WithForkID(),
 				interpreter.WithAfterGenesis(),
+				interpreter.WithAfterChronicle(),
 			); err != nil {
 				return false, fmt.Errorf("%w: %w", ErrScriptVerificationFailed, err)
 			}

--- a/spv/verify_extra_test.go
+++ b/spv/verify_extra_test.go
@@ -140,3 +140,23 @@ func TestSPVVerifyFeeErrorWithMissingSource(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, verified)
 }
+
+// TestSPVVerifyChronicleOpcodes covers script verification under Chronicle
+// rules: an input whose locking script uses a Chronicle re-enabled opcode
+// (OP_2MUL) must verify, as it does on the network.
+func TestSPVVerifyChronicleOpcodes(t *testing.T) {
+	// OP_2 OP_2MUL OP_4 OP_EQUAL → 2*2 == 4 → true, with an empty unlocking script.
+	lock := &script.Script{}
+	require.NoError(t, lock.AppendOpcodes(script.Op2, script.Op2MUL, script.Op4, script.OpEQUAL))
+
+	tx := transaction.NewTransaction()
+	src := transaction.NewTransaction()
+	src.AddOutput(&transaction.TransactionOutput{Satoshis: 100_000, LockingScript: lock})
+	tx.AddInputFromTx(src, 0, nil)
+	tx.Inputs[0].UnlockingScript = &script.Script{}
+	tx.AddOutput(&transaction.TransactionOutput{Satoshis: 1000, LockingScript: lock})
+
+	verified, err := Verify(t.Context(), tx, &GullibleHeadersClient{}, nil)
+	require.NoError(t, err)
+	require.True(t, verified)
+}


### PR DESCRIPTION
## What Changed
- `spv.Verify` now executes input scripts with `interpreter.WithAfterChronicle()` in addition to `WithForkID()` and `WithAfterGenesis()` (Chronicle requires the Genesis flag, so both stay).
- Regression test `TestSPVVerifyChronicleOpcodes`: a transaction spending an `OP_2 OP_2MUL OP_4 OP_EQUAL` locking script must verify.

## Why It Was Necessary
- Chronicle is active on BSV mainnet and re-enabled opcodes such as `OP_2MUL`. `spv.Verify` still ran the interpreter without the Chronicle flag, so any transaction using those opcodes failed with `attempt to execute disabled opcode OP_2MUL` even though nodes accept it. Anything built on `spv.Verify`, e.g. overlay engines that re-verify submitted transactions, silently rejected valid on-chain transactions.
- The interpreter already supports the flag; only this caller was missing it. This mirrors how Genesis rules have always been applied unconditionally here.

## Testing Performed
- `go test ./spv/` green; the new test fails on master and passes with the change.
- Reproduced end to end with a mainnet transaction whose input uses `OP_2MUL`: accepted by the network, rejected by `spv.VerifyScripts` before this change, verified after.

## Impact / Risk
- Scripts that were rejected only because of Chronicle opcodes now verify. Scripts valid under the previous flags are unaffected (Chronicle only re-enables opcodes and relaxes limits).
- Callers verifying against a chain where Chronicle is not active would need an opt-out; none exists today for Genesis either.

## Notifications
- @shruggr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx5sZAzXt8eFUcZzU6ETxZ